### PR TITLE
VoodooI2CHID: Use the lowest button if there is no kHIDUsage_Button_1

### DIFF
--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -577,7 +577,10 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::parseDigitizerElement(IOHIDElement* 
             continue;
         }
         
-        if (element->conformsTo(kHIDPage_Button, kHIDUsage_Button_1)) {
+        // On Dell Latitude 7390 2-in-1 the left button has kHIDUsage_Button_2,
+        // and the right button has kHIDUsage_Button_3. So, there is no button 1.
+        if (element->conformsTo(kHIDPage_Button) && 
+            (digitiser.button == nullptr || element->getUsage() < digitiser.button->getUsage())) {
             digitiser.button = element;
         }
     }

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -168,10 +168,13 @@ void VoodooI2CMultitouchHIDEventDriver::handleDigitizerReport(AbsoluteTime times
     }
     
     // Now handle button report
-    if (digitiser.button) {
+    if (digitiser.primaryButton) { // there can't be secondary button without primary
         VoodooI2CDigitiserTransducer* transducer = OSDynamicCast(VoodooI2CDigitiserTransducer, digitiser.transducers->getObject(0));
         if (transducer) {
-            setButtonState(&transducer->physical_button, 0, digitiser.button->getValue(), timestamp);
+            setButtonState(&transducer->physical_button, 0, digitiser.primaryButton->getValue(), timestamp);
+            if (digitiser.secondaryButton) {
+                setButtonState(&transducer->physical_button, 1, digitiser.secondaryButton->getValue(), timestamp);
+            }
         }
     }
 
@@ -579,9 +582,21 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::parseDigitizerElement(IOHIDElement* 
         
         // On Dell Latitude 7390 2-in-1 the left button has kHIDUsage_Button_2,
         // and the right button has kHIDUsage_Button_3. So, there is no button 1.
-        if (element->conformsTo(kHIDPage_Button) && 
-            (digitiser.button == nullptr || element->getUsage() < digitiser.button->getUsage())) {
-            digitiser.button = element;
+        if (element->conformsTo(kHIDPage_Button)) {
+            if (digitiser.primaryButton == nullptr) {
+                digitiser.primaryButton = element;
+            }
+            else if (element->getUsage() > digitiser.primaryButton->getUsage()) {
+                // Candidate for a secondary button
+                if (digitiser.secondaryButton == nullptr || element->getUsage() < digitiser.secondaryButton->getUsage()) {
+                    digitiser.secondaryButton = element;
+                }
+            }
+            else if (element->getUsage() < digitiser.primaryButton->getUsage()) {
+                // This is the new primary button. Old primary becomes secondary.
+                digitiser.secondaryButton = digitiser.primaryButton;
+                digitiser.primaryButton = element;
+            }
         }
     }
 
@@ -738,7 +753,8 @@ void VoodooI2CMultitouchHIDEventDriver::setDigitizerProperties() {
     properties->setObject("Contact Count Element",         digitiser.contact_count);
     properties->setObject("Input Mode Element",            digitiser.input_mode);
     properties->setObject("Contact Count Maximum Element", digitiser.contact_count_maximum);
-    properties->setObject("Button Element",                digitiser.button);
+    properties->setObject("Primary Button Element",        digitiser.primaryButton);
+    properties->setObject("Secondary Button Element",      digitiser.secondaryButton);
     setOSDictionaryNumber(properties, "Transducer Count",  digitiser.transducers->getCount());
 
     setProperty("Digitizer", properties);

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
@@ -62,13 +62,14 @@ class EXPORT VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
         OSArray*           styluses = NULL;
         
         OSArray*           wrappers = NULL;
-        OSArray*           transducers= NULL;
+        OSArray*           transducers = NULL;
         
         // report level elements
         
         IOHIDElement*      contact_count = NULL;
         IOHIDElement*      input_mode = NULL;
-        IOHIDElement*      button = NULL;
+        IOHIDElement*      primaryButton = NULL;
+        IOHIDElement*      secondaryButton = NULL;
         
         // collection level elements
         

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
@@ -66,13 +66,13 @@ class EXPORT VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
         
         // report level elements
         
-        IOHIDElement*      contact_count;
-        IOHIDElement*      input_mode;
-        IOHIDElement*      button;
+        IOHIDElement*      contact_count = NULL;
+        IOHIDElement*      input_mode = NULL;
+        IOHIDElement*      button = NULL;
         
         // collection level elements
         
-        IOHIDElement*      contact_count_maximum;
+        IOHIDElement*      contact_count_maximum = NULL;
     
         
         UInt8              current_contact_count = 1;


### PR DESCRIPTION
On my Dell Latitude 7390 2-in-1 there is no button with `kHIDUsage_Button_1`. There are two buttons on the touchpad, and they have `kHIDUsage_Button_2` and `kHIDUsage_Button_3`. This patch makes VoodooI2CHID use a button with the lowest usage specified.

2-button support will be added in a separate PR, as it involves changing Input, I2C and PS2 projects.