### PR TITLE
Skip reset on wake up for 0911:5288 and 2386:3118

### DIFF
--- a/VoodooI2CHID/VoodooI2CHIDDevice.cpp
+++ b/VoodooI2CHID/VoodooI2CHIDDevice.cpp
@@ -411,15 +411,22 @@ IOReturn VoodooI2CHIDDevice::setPowerState(unsigned long whichState, IOService* 
         if (!awake) {
             awake = true;
 
-            setHIDPowerState(kVoodooI2CStateOn);
+            if (hid_descriptor.wVendorID == I2C_VENDOR_ID_HANTICK &&
+                hid_descriptor.wProductID == I2C_PRODUCT_ID_HANTICK_5288) {
+                resetHIDDevice();
+                IOSleep(100);
+            } else {
+                setHIDPowerState(kVoodooI2CStateOn);
 
-            VoodooI2CHIDDeviceCommand command;
-            command.c.reg = hid_descriptor.wCommandRegister;
-            command.c.opcode = 0x01;
-            command.c.report_type_id = 0;
+                VoodooI2CHIDDeviceCommand command;
+                command.c.reg = hid_descriptor.wCommandRegister;
+                command.c.opcode = 0x01;
+                command.c.report_type_id = 0;
 
-            api->writeI2C(command.data, 4);
-            IOSleep(10);
+                api->writeI2C(command.data, 4);
+
+                IOSleep(10);
+            }
 
             startInterrupt();
 

--- a/VoodooI2CHID/VoodooI2CHIDDevice.cpp
+++ b/VoodooI2CHID/VoodooI2CHIDDevice.cpp
@@ -411,13 +411,13 @@ IOReturn VoodooI2CHIDDevice::setPowerState(unsigned long whichState, IOService* 
         if (!awake) {
             awake = true;
 
+            setHIDPowerState(kVoodooI2CStateOn);
+
             if (hid_descriptor.wVendorID == I2C_VENDOR_ID_HANTICK &&
                 hid_descriptor.wProductID == I2C_PRODUCT_ID_HANTICK_5288) {
-                resetHIDDevice();
+                setProperty("I2C_HID_QUIRK_NO_IRQ_AFTER_RESET", true);
                 IOSleep(100);
             } else {
-                setHIDPowerState(kVoodooI2CStateOn);
-
                 VoodooI2CHIDDeviceCommand command;
                 command.c.reg = hid_descriptor.wCommandRegister;
                 command.c.opcode = 0x01;

--- a/VoodooI2CHID/VoodooI2CHIDDevice.hpp
+++ b/VoodooI2CHID/VoodooI2CHIDDevice.hpp
@@ -26,6 +26,9 @@
 #define I2C_HID_PWR_ON  0x00
 #define I2C_HID_PWR_SLEEP 0x01
 
+#define I2C_VENDOR_ID_HANTICK        0x0911
+#define I2C_PRODUCT_ID_HANTICK_5288    0x5288
+
 #define EXPORT __attribute__((visibility("default")))
 
 typedef union {

--- a/VoodooI2CHID/VoodooI2CHIDDevice.hpp
+++ b/VoodooI2CHID/VoodooI2CHIDDevice.hpp
@@ -26,8 +26,12 @@
 #define I2C_HID_PWR_ON  0x00
 #define I2C_HID_PWR_SLEEP 0x01
 
+#define I2C_HID_QUIRK_NO_IRQ_AFTER_RESET    BIT(1)
+
 #define I2C_VENDOR_ID_HANTICK        0x0911
 #define I2C_PRODUCT_ID_HANTICK_5288    0x5288
+#define I2C_VENDOR_ID_RAYDIUM        0x2386
+#define I2C_PRODUCT_ID_RAYDIUM_3118    0x3118
 
 #define EXPORT __attribute__((visibility("default")))
 
@@ -205,6 +209,8 @@ class EXPORT VoodooI2CHIDDevice : public IOHIDDevice {
     OSArray* clients;
 
     VoodooI2CHIDDeviceHIDDescriptor hid_descriptor;
+
+    UInt32 quirks;
 
     IOReturn resetHIDDeviceGated();
 


### PR DESCRIPTION
Implementation of `I2C_HID_QUIRK_NO_IRQ_AFTER_RESET`. https://patchwork.kernel.org/project/linux-input/patch/20171106150041.13933-1-hdegoede@redhat.com/
Fix https://github.com/VoodooI2C/VoodooI2C/issues/399