### PR TITLE
Enable USB precision touchpad support

### DIFF
--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -95,11 +95,6 @@
 			</array>
 			<key>IOMatchCategory</key>
 			<string>VoodooI2CHIDMultitouch</string>
-			<key>IOPropertyMatch</key>
-			<dict>
-				<key>Transport</key>
-				<string>I2C</string>
-			</dict>
 			<key>IOProbeScore</key>
 			<integer>300</integer>
 			<key>IOClass</key>

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
@@ -12,9 +12,6 @@
 OSDefineMetaClassAndStructors(VoodooI2CPrecisionTouchpadHIDEventDriver, VoodooI2CMultitouchHIDEventDriver);
 
 void VoodooI2CPrecisionTouchpadHIDEventDriver::enterPrecisionTouchpadMode() {
-    // We should really do this using `input_mode_element->setValue(INPUT_MODE_TOUCHPAD)`
-    // but I am not able to get it to work.
-
     digitiser.input_mode->setValue(INPUT_MODE_TOUCHPAD);
 
     ready = true;

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
@@ -15,15 +15,7 @@ void VoodooI2CPrecisionTouchpadHIDEventDriver::enterPrecisionTouchpadMode() {
     // We should really do this using `input_mode_element->setValue(INPUT_MODE_TOUCHPAD)`
     // but I am not able to get it to work.
 
-    VoodooI2CPrecisionTouchpadFeatureReport buffer;
-    buffer.value = INPUT_MODE_TOUCHPAD;
-    buffer.reserved = 0x00;
-
-    IOBufferMemoryDescriptor* report = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, sizeof(VoodooI2CPrecisionTouchpadFeatureReport));
-    report->writeBytes(0, &buffer, sizeof(VoodooI2CPrecisionTouchpadFeatureReport));
-
-    hid_interface->setReport(report, kIOHIDReportTypeFeature, digitiser.input_mode->getReportID());
-    report->release();
+    digitiser.input_mode->setValue(INPUT_MODE_TOUCHPAD);
 
     ready = true;
 }

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.hpp
@@ -23,11 +23,6 @@
 #define INPUT_MODE_MOUSE 0x00
 #define INPUT_MODE_TOUCHPAD 0x03
 
-typedef struct __attribute__((__packed__)) {
-    UInt8 value;
-    UInt8 reserved;
-} VoodooI2CPrecisionTouchpadFeatureReport;
-
 /* Implements an HID Event Driver for Precision Touchpad devices as specified by Microsoft's protocol in the following document: https://docs.microsoft.com/en-us/windows-hardware/design/component-guidelines/precision-touchpad-devices
  *
  * The members of this class are responsible for instructing a Precision Touchpad device to enter Touchpad mode.


### PR DESCRIPTION
On bigsur 11.1 along with the current master branch of VoodooI2C, `digitiser.input_mode->setValue(INPUT_MODE_TOUCHPAD);` works on both I2C(lenovo yoga530) and USB(keyboard dock for a acer switch 11v sw5-173), with one quirk being the 3 points touch usb touchpad does not show up in system preference->trackpad and I have yet to figure out why (after some reading probably due to the unpatched broadwell acpi battery not working)

existing implementation utilizing `hid_interface->setReport` does not work on USB; touchpad does not enter touchpad mode hence sending 0 coordinates only, hotplugging the keyboard dock causing the whole dock to stop functioning, while `digitiser.input_mode->setValue` works on both my I2C and USB touchpads