### PR TITLE
Stop interrupts after power off, start before power on/reset

### DIFF
--- a/VoodooI2CHID/VoodooI2CHIDDevice.cpp
+++ b/VoodooI2CHID/VoodooI2CHIDDevice.cpp
@@ -414,9 +414,9 @@ IOReturn VoodooI2CHIDDevice::setPowerState(unsigned long whichState, IOService* 
         return kIOReturnInvalid;
     if (whichState == 0) {
         if (awake) {
-            stopInterrupt();
-
             setHIDPowerState(kVoodooI2CStateOff);
+
+            stopInterrupt();
 
             IOLog("%s::%s Going to sleep\n", getName(), name);
             awake = false;
@@ -425,13 +425,13 @@ IOReturn VoodooI2CHIDDevice::setPowerState(unsigned long whichState, IOService* 
         if (!awake) {
             awake = true;
 
+            startInterrupt();
+
             if (quirks & I2C_HID_QUIRK_RESET_ON_RESUME) {
                 resetHIDDevice();
             } else {
                 setHIDPowerState(kVoodooI2CStateOn);
             }
-
-            startInterrupt();
 
             IOLog("%s::%s Woke up\n", getName(), name);
         }


### PR DESCRIPTION
Devices with the I2C_HID_QUIRK_RESET_ON_RESUME quirk will wait for an interrupt after the device reset upon wake.
Interrupts were only enabled after the reset, making devices timeout waiting for them as a signal of a successful reset.

Devices with the I2C_HID_QUIRK_NO_IRQ_AFTER_RESET quirk were the primary reason for the previous change, making the bug hidden until it was recently reported.

Same behavior may be seen in the [Linux i2c-hid driver](https://github.com/torvalds/linux/blob/master/drivers/hid/i2c-hid/i2c-hid-core.c) (Well, it wouldn't work otherwise).