### PR TITLE
Add support for Surface Pro 5/2017 Keyboard/Trackpad

### DIFF
--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -13,6 +13,16 @@
 #include <IOKit/bluetooth/BluetoothAssignedNumbers.h>
 #include <IOKit/IOLib.h>
 
+#include <IOKit/hid/AppleHIDUsageTables.h>
+
+#define SET_NUMBER(key, num) do { \
+tmpNumber = OSNumber::withNumber(num, 32); \
+if (tmpNumber) { \
+kbEnableEventProps->setObject(key, tmpNumber); \
+tmpNumber->release(); \
+} \
+}while (0);
+
 #define GetReportType(type)                                             \
 ((type <= kIOHIDElementTypeInput_ScanCodes) ? kIOHIDReportTypeInput :   \
 (type <= kIOHIDElementTypeOutput) ? kIOHIDReportTypeOutput :            \
@@ -129,6 +139,8 @@ void VoodooI2CMultitouchHIDEventDriver::handleInterruptReport(AbsoluteTime times
     } else {
         digitiser.current_report++;
     }
+    
+    handleKeboardReport(timestamp, report_id);
 }
 
 void VoodooI2CMultitouchHIDEventDriver::handleDigitizerReport(AbsoluteTime timestamp, UInt32 report_id) {
@@ -378,6 +390,97 @@ void VoodooI2CMultitouchHIDEventDriver::handleDigitizerTransducerReport(VoodooI2
         return;
 }
 
+void VoodooI2CMultitouchHIDEventDriver::handleKeboardReport(AbsoluteTime timeStamp, UInt32 reportID) {
+    UInt32      volumeHandled   = 0;
+    UInt32      volumeState     = 0;
+    UInt32      index, count;
+    
+    if(!keyboard.elements)
+        goto exit;
+    
+    for (index=0, count=keyboard.elements->getCount(); index<count; index++) {
+        IOHIDElement *  element;
+        AbsoluteTime    elementTimeStamp;
+        UInt32          usagePage, usage, value, preValue;
+        
+        element = OSDynamicCast(IOHIDElement, keyboard.elements->getObject(index));
+        if ( !element )
+            continue;
+        
+        if ( element->getReportID() != reportID )
+            continue;
+        
+        elementTimeStamp = element->getTimeStamp();
+        if ( CMP_ABSOLUTETIME(&timeStamp, &elementTimeStamp) != 0 )
+            continue;
+        
+        preValue    = element->getValue(kIOHIDValueOptionsFlagPrevious) != 0;
+        value       = element->getValue() != 0;
+        
+        if ( value == preValue )
+            continue;
+        
+        usagePage   = element->getUsagePage();
+        usage       = element->getUsage();
+        
+        if ( usagePage == kHIDPage_Consumer ) {
+            bool suppress = true;
+            switch ( usage ) {
+                case kHIDUsage_Csmr_VolumeIncrement:
+                    volumeHandled   |= 0x1;
+                    volumeState     |= (value) ? 0x1:0;
+                    break;
+                case kHIDUsage_Csmr_VolumeDecrement:
+                    volumeHandled   |= 0x2;
+                    volumeState     |= (value) ? 0x2:0;
+                    break;
+                case kHIDUsage_Csmr_Mute:
+                    volumeHandled   |= 0x4;
+                    volumeState     |= (value) ? 0x4:0;
+                    break;
+                default:
+                    suppress = false;
+                    break;
+            }
+            
+            if ( suppress )
+                continue;
+        }
+        
+        /* Disabled due to non-avaiablitity of identifiers
+         
+         else if (usage == kHIDUsage_KeyboardPower && usagePage == kHIDPage_KeyboardOrKeypad) {
+         if (value == 0) {
+         setProperty(kIOHIDKeyboardEnabledKey, kOSBooleanFalse);
+         }
+         
+         else {
+         setProperty(kIOHIDKeyboardEnabledKey, kOSBooleanTrue);
+         }
+         }*/
+        
+        dispatchKeyboardEvent(timeStamp, usagePage, usage, value);
+    }
+    
+    // RY: Handle the case where Vol Increment, Decrement, and Mute are all down
+    // If such an event occurs, it is likely that the device is defective,
+    // and should be ignored.
+    if ( (volumeState != 0x7) && (volumeHandled != 0x7) ) {
+        // Volume Increment
+        if ( volumeHandled & 0x1 )
+            dispatchKeyboardEvent(timeStamp, kHIDPage_Consumer, kHIDUsage_Csmr_VolumeIncrement, ((volumeState & 0x1) != 0));
+        // Volume Decrement
+        if ( volumeHandled & 0x2 )
+            dispatchKeyboardEvent(timeStamp, kHIDPage_Consumer, kHIDUsage_Csmr_VolumeDecrement, ((volumeState & 0x2) != 0));
+        // Volume Mute
+        if ( volumeHandled & 0x4 )
+            dispatchKeyboardEvent(timeStamp, kHIDPage_Consumer, kHIDUsage_Csmr_Mute, ((volumeState & 0x4) != 0));
+    }
+    
+exit:
+    return;
+}
+
 bool VoodooI2CMultitouchHIDEventDriver::handleStart(IOService* provider) {
     if(!super::handleStart(provider)) {
         return false;
@@ -440,6 +543,7 @@ bool VoodooI2CMultitouchHIDEventDriver::handleStart(IOService* provider) {
         return false;
 
     setDigitizerProperties();
+    setKeyboardProperties();
 
     PMinit();
     hid_interface->joinPMtree(this);
@@ -596,6 +700,132 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::parseDigitizerElement(IOHIDElement* 
 
     return kIOReturnSuccess;
 }
+
+bool VoodooI2CMultitouchHIDEventDriver::parseKeyboardElement(IOHIDElement * element) {
+    UInt32 usagePage    = element->getUsagePage();
+    UInt32 usage        = element->getUsage();
+    bool   store        = false;
+    
+    if (!keyboard.elements) {
+        keyboard.elements = OSArray::withCapacity(4);
+        if(!keyboard.elements)
+            goto exit;
+    }
+    
+    switch (usagePage) {
+        case kHIDPage_GenericDesktop:
+            switch (usage) {
+                case kHIDUsage_GD_Start:
+                case kHIDUsage_GD_Select:
+                case kHIDUsage_GD_SystemPowerDown:
+                case kHIDUsage_GD_SystemSleep:
+                case kHIDUsage_GD_SystemWakeUp:
+                case kHIDUsage_GD_SystemContextMenu:
+                case kHIDUsage_GD_SystemMainMenu:
+                case kHIDUsage_GD_SystemAppMenu:
+                case kHIDUsage_GD_SystemMenuHelp:
+                case kHIDUsage_GD_SystemMenuExit:
+                case kHIDUsage_GD_SystemMenuSelect:
+                case kHIDUsage_GD_SystemMenuRight:
+                case kHIDUsage_GD_SystemMenuLeft:
+                case kHIDUsage_GD_SystemMenuUp:
+                case kHIDUsage_GD_SystemMenuDown:
+                case kHIDUsage_GD_DPadUp:
+                case kHIDUsage_GD_DPadDown:
+                case kHIDUsage_GD_DPadRight:
+                case kHIDUsage_GD_DPadLeft:
+                    store = true;
+                    break;
+            }
+            break;
+        case kHIDPage_KeyboardOrKeypad:
+            if ((usage < kHIDUsage_KeyboardA) || (usage > kHIDUsage_KeyboardRightGUI))
+                break;
+            
+            // This usage is used to let the OS know if a keyboard is in an enabled state where
+            // user input is possible
+            
+            if (usage == kHIDUsage_KeyboardPower) {
+                OSDictionary * kbEnableEventProps   = NULL;
+                UInt32 value                        = 0;
+                
+                // To avoid problems with un-intentional clearing of the flag
+                // we require this report to be a feature report so that the current
+                // state can be polled if necessary
+                
+                if (element->getType() == kIOHIDElementTypeFeature) {
+                    value = element->getValue(kIOHIDValueOptionsUpdateElementValues);
+                    
+                    kbEnableEventProps = OSDictionary::withCapacity(3);
+                    if (!kbEnableEventProps)
+                        break;
+                    
+                    /* Since the identifiers are not defined, better comment out
+                     
+                     SET_NUMBER(kIOHIDKeyboardEnabledEventEventTypeKey, kIOHIDEventTypeKeyboard);
+                     SET_NUMBER(kIOHIDKeyboardEnabledEventUsagePageKey, kHIDPage_KeyboardOrKeypad);
+                     SET_NUMBER(kIOHIDKeyboardEnabledEventUsageKey, kHIDUsage_KeyboardPower);
+                     
+                     setProperty(kIOHIDKeyboardEnabledEventKey, kbEnableEventProps);
+                     setProperty(kIOHIDKeyboardEnabledByEventKey, kOSBooleanTrue);
+                     setProperty(kIOHIDKeyboardEnabledKey, value ? kOSBooleanTrue : kOSBooleanFalse);*/
+                    
+                    kbEnableEventProps->release();
+                }
+                
+                store = true;
+                break;
+            }
+        case kHIDPage_Consumer:
+            if (usage == kHIDUsage_Csmr_ACKeyboardLayoutSelect)
+                setProperty(kIOHIDSupportsGlobeKeyKey, kOSBooleanTrue);
+        case kHIDPage_Telephony:
+            store = true;
+            break;
+        case kHIDPage_AppleVendorTopCase:
+            if (keyboard.appleVendorSupported) {
+                switch (usage) {
+                    case kHIDUsage_AV_TopCase_BrightnessDown:
+                    case kHIDUsage_AV_TopCase_BrightnessUp:
+                    case kHIDUsage_AV_TopCase_IlluminationDown:
+                    case kHIDUsage_AV_TopCase_IlluminationUp:
+                    case kHIDUsage_AV_TopCase_KeyboardFn:
+                        store = true;
+                        break;
+                }
+            }
+            break;
+        case kHIDPage_AppleVendorKeyboard:
+            if (keyboard.appleVendorSupported) {
+                switch (usage) {
+                    case kHIDUsage_AppleVendorKeyboard_Spotlight:
+                    case kHIDUsage_AppleVendorKeyboard_Dashboard:
+                    case kHIDUsage_AppleVendorKeyboard_Function:
+                    case kHIDUsage_AppleVendorKeyboard_Launchpad:
+                    case kHIDUsage_AppleVendorKeyboard_Reserved:
+                    case kHIDUsage_AppleVendorKeyboard_CapsLockDelayEnable:
+                    case kHIDUsage_AppleVendorKeyboard_PowerState:
+                    case kHIDUsage_AppleVendorKeyboard_Expose_All:
+                    case kHIDUsage_AppleVendorKeyboard_Expose_Desktop:
+                    case kHIDUsage_AppleVendorKeyboard_Brightness_Up:
+                    case kHIDUsage_AppleVendorKeyboard_Brightness_Down:
+                    case kHIDUsage_AppleVendorKeyboard_Language:
+                        store = true;
+                        break;
+                }
+            }
+            break;
+    }
+    
+    if(!store)
+        goto exit;
+    
+    keyboard.elements->setObject(element);
+    
+exit:
+    return store;
+}
+
     
 IOReturn VoodooI2CMultitouchHIDEventDriver::parseElements() {
     int index, count;
@@ -696,6 +926,30 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::parseElements() {
         digitiser.transducers->setObject(0, transducer);
         stylus_wrapper->release();
     }
+    
+    //Keyboard : Loop through all createMatchingElements() and parse KeyboardElements
+        
+    OSArray *elementArray = hid_interface->createMatchingElements();
+    keyboard.appleVendorSupported = getProperty(kIOHIDAppleVendorSupported, gIOServicePlane);
+    if (elementArray) {
+        for (index=0, count=elementArray->getCount(); index<count; index++) {
+            IOHIDElement *  element     = NULL;
+            
+            element = OSDynamicCast(IOHIDElement, elementArray->getObject(index));
+            if (!element)
+                continue;
+            
+            if (element->getType() == kIOHIDElementTypeCollection)
+                continue;
+            
+            if (element->getUsage() == 0)
+                continue;
+            
+            if (parseKeyboardElement(element))
+                continue;
+        }
+    }
+    OSSafeReleaseNULL(elementArray);
 
     return kIOReturnSuccess;
 }
@@ -753,6 +1007,24 @@ void VoodooI2CMultitouchHIDEventDriver::setDigitizerProperties() {
 
     setProperty("Digitizer", properties);
 
+    OSSafeReleaseNULL(properties);
+}
+
+void VoodooI2CMultitouchHIDEventDriver::setKeyboardProperties()
+{
+    OSDictionary *properties = OSDictionary::withCapacity(4);
+    
+    if (!properties)
+        return;
+    
+    if (!keyboard.elements)
+        return;
+    
+    properties->setObject(kIOHIDElementKey, keyboard.elements);
+    
+    setProperty("Keyboard", properties);
+    
+exit:
     OSSafeReleaseNULL(properties);
 }
 

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
@@ -84,6 +84,12 @@ class EXPORT VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
         UInt8              current_report = 1;
     } digitiser;
 
+    struct {
+            OSArray *           elements;
+            UInt8               bootMouseData[4];
+            bool                appleVendorSupported;
+    } keyboard;
+    
     /* Calibrates an HID element
      * @element The element to be calibrated
      * @removalPercentage The percentage by which the element is calibrated
@@ -110,6 +116,14 @@ class EXPORT VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
     UInt32 getElementValue(IOHIDElement* element);
     
     const char* getProductName();
+    
+    /* Called during the interrupt routine to interate over keyboard events
+     * @timestamp The timestamp of the interrupt report
+     * @report_id The report ID of the interrupt report
+     */
+
+    void handleKeboardReport(AbsoluteTime timeStamp, UInt32 reportID);
+
 
     /* Called during the interrupt routine to interate over transducers
      * @timestamp The timestamp of the interrupt report
@@ -177,6 +191,18 @@ class EXPORT VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
      */
 
     IOReturn parseDigitizerTransducerElement(IOHIDElement* element, IOHIDElement* parent);
+    
+    /* Parses a keyboard usage page element
+     * @element The element to parse
+     *
+     * This function is reponsible for examining the child elements of a digitser elements to determine the
+     * capabilities of the keyboard.
+     *
+     * @return *true* on successful parse, *false* otherwise
+     */
+
+    bool parseKeyboardElement(IOHIDElement* element);
+
 
     /* Parses all matched elements
      *
@@ -212,6 +238,7 @@ class EXPORT VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
      */
 
     void setDigitizerProperties();
+    void setKeyboardProperties();
 
     /* Called by the OS in order to notify the driver that the device should change power state
      * @whichState The power state the device is expected to enter represented by either


### PR DESCRIPTION
This should help add support for Surface Pro 5/2017 to allow Keyboard/Trackpad support with Voodooi2c/Voodooi2cHID.

Confirmed that it has been tested and working as it should. Both Keyboard/Trackpad are working on the latest build with these additions.