### PR TITLE
Add Keyboard support

### DIFF
--- a/VoodooI2CHID.xcodeproj/project.pbxproj
+++ b/VoodooI2CHID.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0FD0AFEC258E44F900C77E6A /* libkmod.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FD0AFEB258E44F900C77E6A /* libkmod.a */; };
+		2814C7C426BD9C4A00A5999D /* VoodooI2CKeyboardHIDEventDriver.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2814C7C226BD9C4900A5999D /* VoodooI2CKeyboardHIDEventDriver.hpp */; };
+		2814C7C526BD9C4A00A5999D /* VoodooI2CKeyboardHIDEventDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2814C7C326BD9C4A00A5999D /* VoodooI2CKeyboardHIDEventDriver.cpp */; };
 		4E9F1E831F8AFECD00E91849 /* VoodooI2CTouchscreenHIDEventDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E9F1E811F8AFECD00E91849 /* VoodooI2CTouchscreenHIDEventDriver.cpp */; };
 		4E9F1E841F8AFECD00E91849 /* VoodooI2CTouchscreenHIDEventDriver.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4E9F1E821F8AFECD00E91849 /* VoodooI2CTouchscreenHIDEventDriver.hpp */; };
 		AC01EE9C201E2B7D005A2988 /* VoodooI2CAccelerometerSensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AC01EE9A201E2B7D005A2988 /* VoodooI2CAccelerometerSensor.cpp */; };
@@ -38,6 +40,8 @@
 
 /* Begin PBXFileReference section */
 		0FD0AFEB258E44F900C77E6A /* libkmod.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libkmod.a; path = ../../MacKernelSDK/Library/x86_64/libkmod.a; sourceTree = "<group>"; };
+		2814C7C226BD9C4900A5999D /* VoodooI2CKeyboardHIDEventDriver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = VoodooI2CKeyboardHIDEventDriver.hpp; sourceTree = "<group>"; };
+		2814C7C326BD9C4A00A5999D /* VoodooI2CKeyboardHIDEventDriver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooI2CKeyboardHIDEventDriver.cpp; sourceTree = "<group>"; };
 		4E9F1E811F8AFECD00E91849 /* VoodooI2CTouchscreenHIDEventDriver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooI2CTouchscreenHIDEventDriver.cpp; sourceTree = "<group>"; };
 		4E9F1E821F8AFECD00E91849 /* VoodooI2CTouchscreenHIDEventDriver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = VoodooI2CTouchscreenHIDEventDriver.hpp; sourceTree = "<group>"; };
 		AC01EE9A201E2B7D005A2988 /* VoodooI2CAccelerometerSensor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VoodooI2CAccelerometerSensor.cpp; path = Sensors/VoodooI2CAccelerometerSensor.cpp; sourceTree = "<group>"; };
@@ -116,6 +120,8 @@
 				AC0DE5ED1F4FFDB2006149C8 /* VoodooI2CHIDDevice.hpp */,
 				ACCFCF211F69C1DC003E4131 /* VoodooI2CMultitouchHIDEventDriver.cpp */,
 				ACCFCF221F69C1DC003E4131 /* VoodooI2CMultitouchHIDEventDriver.hpp */,
+				2814C7C326BD9C4A00A5999D /* VoodooI2CKeyboardHIDEventDriver.cpp */,
+				2814C7C226BD9C4900A5999D /* VoodooI2CKeyboardHIDEventDriver.hpp */,
 				AC0556971F7333FB00ABFD91 /* VoodooI2CPrecisionTouchpadHIDEventDriver.cpp */,
 				AC0556981F7333FB00ABFD91 /* VoodooI2CPrecisionTouchpadHIDEventDriver.hpp */,
 				4E9F1E811F8AFECD00E91849 /* VoodooI2CTouchscreenHIDEventDriver.cpp */,
@@ -171,6 +177,7 @@
 				AC6388CD201B8E9F005E1341 /* VoodooI2CDeviceOrientationSensor.hpp in Headers */,
 				AC0ADA352017C2DC004DB693 /* VoodooI2CStylusHIDEventDriver.hpp in Headers */,
 				4E9F1E841F8AFECD00E91849 /* VoodooI2CTouchscreenHIDEventDriver.hpp in Headers */,
+				2814C7C426BD9C4A00A5999D /* VoodooI2CKeyboardHIDEventDriver.hpp in Headers */,
 				ACE41BFE22FE5BCF00F75673 /* VoodooI2CHIDSYNA3602Device.hpp in Headers */,
 				AC01EEA1201E2BAB005A2988 /* VoodooI2CSensor.hpp in Headers */,
 				AC0DE5EF1F4FFDB2006149C8 /* VoodooI2CHIDDevice.hpp in Headers */,
@@ -251,6 +258,7 @@
 			files = (
 				ACE41BF922FE565000F75673 /* VoodooI2CHIDDeviceOverride.cpp in Sources */,
 				AC0556991F7333FB00ABFD91 /* VoodooI2CPrecisionTouchpadHIDEventDriver.cpp in Sources */,
+				2814C7C526BD9C4A00A5999D /* VoodooI2CKeyboardHIDEventDriver.cpp in Sources */,
 				AC0E628B201A629A00A31157 /* VoodooI2CSensorHubEventDriver.cpp in Sources */,
 				4E9F1E831F8AFECD00E91849 /* VoodooI2CTouchscreenHIDEventDriver.cpp in Sources */,
 				AC01EE9C201E2B7D005A2988 /* VoodooI2CAccelerometerSensor.cpp in Sources */,

--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -141,6 +141,28 @@
 			<key>IOProviderClass</key>
 			<string>IOHIDInterface</string>
 		</dict>
+		<key>VoodooI2CHIDDevice Keyboard HID Event Driver</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>DeviceUsagePairs</key>
+			<array>
+				<dict>
+					<key>DeviceUsage</key>
+					<integer>6</integer>
+					<key>DeviceUsagePage</key>
+					<integer>1</integer>
+				</dict>
+			</array>
+			<key>IOProbeScore</key>
+			<integer>200</integer>
+			<key>IOMatchCategory</key>
+			<string>VoodooI2CKeyboardHIDEventDriver</string>
+			<key>IOClass</key>
+			<string>VoodooI2CKeyboardHIDEventDriver</string>
+			<key>IOProviderClass</key>
+			<string>IOHIDInterface</string>
+		</dict>
 		<key>VoodooI2CHIDDevice Generic Mouse HID Event Driver</key>
 		<dict>
 			<key>CFBundleIdentifier</key>

--- a/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.cpp
@@ -1,0 +1,479 @@
+//
+//  VoodooI2CKeyboardHIDEventDriver.cpp
+//  VoodooI2CHID
+//
+//  Created by 夏尚宁 on 2021/3/17.
+//  Copyright © 2021 Alexandre Daoud. All rights reserved.
+//
+
+#include "VoodooI2CKeyboardHIDEventDriver.hpp"
+#include <IOKit/IOCommandGate.h>
+#include <IOKit/hid/IOHIDInterface.h>
+#include <IOKit/usb/USBSpec.h>
+#include <IOKit/bluetooth/BluetoothAssignedNumbers.h>
+#include <IOKit/IOLib.h>
+
+#include <IOKit/hid/AppleHIDUsageTables.h>
+
+#define MAX_PATH_LEN 256
+
+#define SET_NUMBER(key, num) do { \
+    tmpNumber = OSNumber::withNumber(num, 32); \
+    if (tmpNumber) { \
+        kbEnableEventProps->setObject(key, tmpNumber); \
+        tmpNumber->release(); \
+    } \
+}while (0);
+
+// constants for processing the special key input event
+#define kHIDIncrVolume  0x01
+#define kHIDDecrVolume  0x02
+#define kHIDMute        0x04
+
+#define GetReportType(type)                                             \
+((type <= kIOHIDElementTypeInput_ScanCodes) ? kIOHIDReportTypeInput :   \
+(type <= kIOHIDElementTypeOutput) ? kIOHIDReportTypeOutput :            \
+(type <= kIOHIDElementTypeFeature) ? kIOHIDReportTypeFeature : -1)
+
+#define super IOHIDEventService
+OSDefineMetaClassAndStructors(VoodooI2CKeyboardHIDEventDriver, IOHIDEventService);
+
+bool VoodooI2CKeyboardHIDEventDriver::didTerminate(IOService *provider, IOOptionBits options, bool *defer) {
+    if (hid_interface)
+        hid_interface->close(this);
+    
+    hid_interface = NULL;
+    return super::didTerminate(provider, options, defer);
+}
+
+UInt32 VoodooI2CKeyboardHIDEventDriver::getElementValue(IOHIDElement *element) {
+    IOHIDElementCookie cookie = element->getCookie();
+    
+    if (!cookie)
+        return 0;
+    
+    hid_device->updateElementValues(&cookie);
+    
+    return element->getValue();
+}
+
+const char *VoodooI2CKeyboardHIDEventDriver::getProductName() {
+    if (OSString* name = getProduct())
+        return name->getCStringNoCopy();
+
+    return "Keyboard HID Device";
+}
+
+void VoodooI2CKeyboardHIDEventDriver::handleInterruptReport(AbsoluteTime timestamp,
+                                                            IOMemoryDescriptor *report,
+                                                            IOHIDReportType report_type,
+                                                            UInt32 report_id) {
+    UInt32      volumeHandled   = 0;
+    UInt32      volumeState     = 0;
+    UInt32      index, count;
+    
+    if(!keyboard.elements)
+        return;
+    
+    for (index=0, count=keyboard.elements->getCount(); index<count; index++) {
+        IOHIDElement* element = nullptr;
+        AbsoluteTime  elementTimeStamp;
+        UInt32        usagePage, usage, value, preValue;
+        
+        element = OSDynamicCast(IOHIDElement, keyboard.elements->getObject(index));
+        if (!element)
+            continue;
+        
+        if (element->getReportID() != report_id)
+            continue;
+        
+        elementTimeStamp = element->getTimeStamp();
+        if (CMP_ABSOLUTETIME(&timestamp, &elementTimeStamp) != 0)
+            continue;
+        
+        preValue    = element->getValue(kIOHIDValueOptionsFlagPrevious) != 0;
+        value       = element->getValue() != 0;
+        
+        if (value == preValue)
+            continue;
+        
+        usagePage   = element->getUsagePage();
+        usage       = element->getUsage();
+        
+        if (usagePage == kHIDPage_Consumer) {
+            bool suppress = true;
+            switch (usage) {
+                case kHIDUsage_Csmr_VolumeIncrement:
+                    volumeHandled   |= kHIDIncrVolume;
+                    volumeState     |= (value) ? kHIDIncrVolume:0;
+                    break;
+                case kHIDUsage_Csmr_VolumeDecrement:
+                    volumeHandled   |= kHIDDecrVolume;
+                    volumeState     |= (value) ? kHIDDecrVolume:0;
+                    break;
+                case kHIDUsage_Csmr_Mute:
+                    volumeHandled   |= kHIDMute;
+                    volumeState     |= (value) ? kHIDMute:0;
+                    break;
+                default:
+                    suppress = false;
+                    break;
+            }
+            
+            if (suppress)
+                continue;
+        }
+        
+        dispatchKeyboardEvent(timestamp, usagePage, usage, value);
+    }
+    
+    // RY: Handle the case where Vol Increment, Decrement, and Mute are all down
+    // If such an event occurs, it is likely that the device is defective,
+    // and should be ignored.
+    if ((volumeState != (kHIDIncrVolume|kHIDDecrVolume|kHIDMute)) &&
+        (volumeHandled != (kHIDIncrVolume|kHIDDecrVolume|kHIDMute))) {
+        // Volume Increment
+        if (volumeHandled & kHIDIncrVolume)
+            dispatchKeyboardEvent(timestamp, kHIDPage_Consumer, kHIDUsage_Csmr_VolumeIncrement, ((volumeState & kHIDIncrVolume) != 0));
+        // Volume Decrement
+        if (volumeHandled & kHIDDecrVolume)
+            dispatchKeyboardEvent(timestamp, kHIDPage_Consumer, kHIDUsage_Csmr_VolumeDecrement, ((volumeState & kHIDDecrVolume) != 0));
+        // Volume Mute
+        if (volumeHandled & kHIDMute)
+            dispatchKeyboardEvent(timestamp, kHIDPage_Consumer, kHIDUsage_Csmr_Mute, ((volumeState & kHIDMute) != 0));
+    }
+}
+
+bool VoodooI2CKeyboardHIDEventDriver::handleStart(IOService *provider) {
+    if(!super::handleStart(provider)) {
+        return false;
+    }
+    
+    hid_interface = OSDynamicCast(IOHIDInterface, provider);
+
+    if (!hid_interface)
+        return false;
+
+    OSString* transport = hid_interface->getTransport();
+    if (!transport)
+        return false;
+  
+    if (strncmp(transport->getCStringNoCopy(), kIOHIDTransportUSBValue, sizeof(kIOHIDTransportUSBValue)) != 0)
+        hid_interface->setProperty("VoodooI2CServices Supported", kOSBooleanTrue);
+
+    hid_device = OSDynamicCast(IOHIDDevice, hid_interface->getParentEntry(gIOServicePlane));
+    
+    if (!hid_device)
+        return false;
+    
+    name = getProductName();
+
+    if (parseElements() != kIOReturnSuccess) {
+        IOLog("%s::%s Could not parse multitouch elements\n", getName(), name);
+        return false;
+    }
+    
+    if (!hid_interface->open(this, 0, OSMemberFunctionCast(IOHIDInterface::InterruptReportAction, this, &VoodooI2CKeyboardHIDEventDriver::handleInterruptReport), NULL))
+        return false;
+
+    setKeyboardProperties();
+
+    PMinit();
+    hid_interface->joinPMtree(this);
+    registerPowerDriver(this, VoodooI2CIOPMPowerStates, kVoodooI2CIOPMNumberPowerStates);
+
+    return true;
+}
+
+void VoodooI2CKeyboardHIDEventDriver::handleStop(IOService *provider) {
+    if (command_gate) {
+        work_loop->removeEventSource(command_gate);
+        OSSafeReleaseNULL(command_gate);
+    }
+
+    OSSafeReleaseNULL(work_loop);
+
+    PMstop();
+    super::handleStop(provider);
+}
+
+void VoodooI2CKeyboardHIDEventDriver::parseKeyboardElement(IOHIDElement *element) {
+    UInt32 usagePage    = element->getUsagePage();
+    UInt32 usage        = element->getUsage();
+    bool   store        = false;
+    
+    if (!keyboard.elements) {
+        keyboard.elements = OSArray::withCapacity(4);
+        if(!keyboard.elements)
+            return;
+    }
+    
+    switch (usagePage) {
+        case kHIDPage_GenericDesktop:
+            switch (usage) {
+                case kHIDUsage_GD_Start:
+                case kHIDUsage_GD_Select:
+                case kHIDUsage_GD_SystemPowerDown:
+                case kHIDUsage_GD_SystemSleep:
+                case kHIDUsage_GD_SystemWakeUp:
+                case kHIDUsage_GD_SystemContextMenu:
+                case kHIDUsage_GD_SystemMainMenu:
+                case kHIDUsage_GD_SystemAppMenu:
+                case kHIDUsage_GD_SystemMenuHelp:
+                case kHIDUsage_GD_SystemMenuExit:
+                case kHIDUsage_GD_SystemMenuSelect:
+                case kHIDUsage_GD_SystemMenuRight:
+                case kHIDUsage_GD_SystemMenuLeft:
+                case kHIDUsage_GD_SystemMenuUp:
+                case kHIDUsage_GD_SystemMenuDown:
+                case kHIDUsage_GD_DPadUp:
+                case kHIDUsage_GD_DPadDown:
+                case kHIDUsage_GD_DPadRight:
+                case kHIDUsage_GD_DPadLeft:
+                    store = true;
+                    break;
+            }
+            break;
+        case kHIDPage_KeyboardOrKeypad:
+            if ((usage < kHIDUsage_KeyboardA) || (usage > kHIDUsage_KeyboardRightGUI))
+                break;
+            
+            // This usage is used to let the OS know if a keyboard is in an enabled state where
+            // user input is possible
+            
+            if (usage == kHIDUsage_KeyboardPower) {
+                OSDictionary* kbEnableEventProps    = NULL;
+                UInt32 value                        = 0;
+                
+                // To avoid problems with un-intentional clearing of the flag
+                // we require this report to be a feature report so that the current
+                // state can be polled if necessary
+                
+                if (element->getType() == kIOHIDElementTypeFeature) {
+                    value = element->getValue(kIOHIDValueOptionsUpdateElementValues);
+                    
+                    kbEnableEventProps = OSDictionary::withCapacity(3);
+                    if (!kbEnableEventProps)
+                        break;
+                    OSSafeReleaseNULL(kbEnableEventProps);
+                }
+                
+                store = true;
+                break;
+            }
+        case kHIDPage_Consumer:
+            if (usage == kHIDUsage_Csmr_ACKeyboardLayoutSelect)
+                setProperty(kIOHIDSupportsGlobeKeyKey, kOSBooleanTrue);
+        case kHIDPage_Telephony:
+            store = true;
+            break;
+        case kHIDPage_AppleVendorTopCase:
+            if (keyboard.appleVendorSupported) {
+                switch (usage) {
+                    case kHIDUsage_AV_TopCase_BrightnessDown:
+                    case kHIDUsage_AV_TopCase_BrightnessUp:
+                    case kHIDUsage_AV_TopCase_IlluminationDown:
+                    case kHIDUsage_AV_TopCase_IlluminationUp:
+                    case kHIDUsage_AV_TopCase_KeyboardFn:
+                        store = true;
+                        break;
+                }
+            }
+            break;
+        case kHIDPage_AppleVendorKeyboard:
+            if (keyboard.appleVendorSupported) {
+                switch (usage) {
+                    case kHIDUsage_AppleVendorKeyboard_Spotlight:
+                    case kHIDUsage_AppleVendorKeyboard_Dashboard:
+                    case kHIDUsage_AppleVendorKeyboard_Function:
+                    case kHIDUsage_AppleVendorKeyboard_Launchpad:
+                    case kHIDUsage_AppleVendorKeyboard_Reserved:
+                    case kHIDUsage_AppleVendorKeyboard_CapsLockDelayEnable:
+                    case kHIDUsage_AppleVendorKeyboard_PowerState:
+                    case kHIDUsage_AppleVendorKeyboard_Expose_All:
+                    case kHIDUsage_AppleVendorKeyboard_Expose_Desktop:
+                    case kHIDUsage_AppleVendorKeyboard_Brightness_Up:
+                    case kHIDUsage_AppleVendorKeyboard_Brightness_Down:
+                    case kHIDUsage_AppleVendorKeyboard_Language:
+                        store = true;
+                        break;
+                }
+            }
+            break;
+    }
+    
+    if(store) {
+        keyboard.elements->setObject(element);
+    }
+}
+
+    
+IOReturn VoodooI2CKeyboardHIDEventDriver::parseElements() {
+    //Keyboard : Loop through all createMatchingElements() and parse KeyboardElements
+        
+    OSArray *elementArray = hid_interface->createMatchingElements();
+    keyboard.appleVendorSupported = getProperty(kIOHIDAppleVendorSupported, gIOServicePlane);
+    if (elementArray) {
+        for (int i=0, count=elementArray->getCount(); i<count; i++) {
+            IOHIDElement* element   = nullptr;
+            
+            element = OSDynamicCast(IOHIDElement, elementArray->getObject(i));
+            if (!element)
+                continue;
+            
+            if (element->getType() == kIOHIDElementTypeCollection)
+                continue;
+            
+            if (element->getUsage() == 0)
+                continue;
+            
+            parseKeyboardElement(element);
+        }
+    }
+    
+    OSSafeReleaseNULL(elementArray);
+    return kIOReturnSuccess;
+}
+
+void VoodooI2CKeyboardHIDEventDriver::setKeyboardProperties()
+{
+    OSDictionary *properties = OSDictionary::withCapacity(4);
+    
+    if (!properties)
+        return;
+    
+    if (!keyboard.elements)
+        return;
+    
+    properties->setObject(kIOHIDElementKey, keyboard.elements);
+    
+    setProperty("Keyboard", properties);
+    
+exit:
+    OSSafeReleaseNULL(properties);
+}
+
+IOReturn VoodooI2CKeyboardHIDEventDriver::setPowerState(unsigned long whichState, IOService *whatDevice) {
+    return kIOPMAckImplied;
+}
+
+bool VoodooI2CKeyboardHIDEventDriver::start(IOService* provider) {
+    if (!super::start(provider))
+        return false;
+    
+    work_loop = getWorkLoop();
+    
+    if (!work_loop)
+        return false;
+    
+    work_loop->retain();
+    
+    command_gate = IOCommandGate::commandGate(this);
+    if (!command_gate) {
+        return false;
+    }
+    
+    work_loop->addEventSource(command_gate);
+    setProperty("VoodooI2CServices Supported", kOSBooleanTrue);
+
+    return true;
+}
+
+IOReturn VoodooI2CKeyboardHIDEventDriver::message(UInt32 type, IOService* provider, void *argument) {
+    switch (type) {
+        case kKeyboardKeyPressTime:
+        {
+            //  Remember last time key was pressed
+            key_time = *((uint64_t*)argument);
+#if DEBUG
+            IOLog("%s::keyPressed = %llu\n", getName(), key_time);
+#endif
+            break;
+        }
+    }
+
+    return kIOReturnSuccess;
+}
+
+void VoodooI2CKeyboardHIDEventDriver::bluetoothHIDAttached(IOService *newService, char *path) {
+    // Filter on specific CoD (Class of Device) bluetooth devices only
+    OSNumber* propDeviceClass = OSDynamicCast(OSNumber, newService->getProperty("ClassOfDevice"));
+    
+    if (propDeviceClass == NULL)
+        return;
+    
+    long classOfDevice = propDeviceClass->unsigned32BitValue();
+    long deviceClassMajor = (classOfDevice & 0x1F00) >> 8;
+    long deviceClassMinor = (classOfDevice & 0xFF) >> 2;
+    long deviceClassMinor1 = deviceClassMinor & 0x30;
+    long deviceClassMinor2 = deviceClassMinor & 0x0F;
+    
+    if (deviceClassMajor != kBluetoothDeviceClassMajorPeripheral)
+        return;
+    
+    if (deviceClassMinor1 != kBluetoothDeviceClassMinorPeripheral1Pointing &&   // Seperate pointing device
+        deviceClassMinor1 != kBluetoothDeviceClassMinorPeripheral1Combo)        // Combo Bluetooth keyboard/touchpad
+        return;
+    
+    if (deviceClassMinor2 != kBluetoothDeviceClassMinorPeripheral2Unclassified &&       // Mouse
+        deviceClassMinor2 != kBluetoothDeviceClassMinorPeripheral2DigitizerTablet &&    // Magic Touchpad
+        deviceClassMinor2 != kBluetoothDeviceClassMinorPeripheral2DigitalPen)           // Wacom Tablet
+        return;
+    
+    attached_hid_pointer_devices->setObject(newService);
+    IOLog("%s: Bluetooth pointer HID device published: %s, # devices: %d\n", getName(), path, attached_hid_pointer_devices->getCount());
+}
+
+void VoodooI2CKeyboardHIDEventDriver::notificationHIDAttachedHandlerGated(IOService *newService, IONotifier *notifier) {
+    char path[MAX_PATH_LEN];
+    int len = MAX_PATH_LEN;
+    memset(path, 0, len);
+    newService->getPath(path, &len, gIOServicePlane);
+    
+    if (notifier == usb_hid_publish_notify) {
+        IORegistryEntry* hid_child = OSDynamicCast(IORegistryEntry, newService->getChildEntry(gIOServicePlane));
+        
+        if (!hid_child)
+            return;
+
+        OSNumber* primary_usage_page = OSDynamicCast(OSNumber, hid_child->getProperty(kIOHIDPrimaryUsagePageKey));
+        OSNumber* primary_usage = OSDynamicCast(OSNumber, hid_child->getProperty(kIOHIDPrimaryUsageKey));
+        
+        if (!primary_usage_page || !primary_usage)
+            return;
+        
+        // ignore touchscreens
+
+        if (primary_usage_page->unsigned8BitValue() != kHIDPage_Digitizer &&
+            primary_usage->unsigned8BitValue() != kHIDUsage_Dig_TouchScreen) {
+            
+            attached_hid_pointer_devices->setObject(newService);
+            IOLog("%s: USB pointer HID device published: %s, # devices: %d\n", getName(), path, attached_hid_pointer_devices->getCount());
+        }
+    }
+    
+    if (notifier == usb_hid_terminate_notify) {
+        attached_hid_pointer_devices->removeObject(newService);
+        IOLog("%s: USB pointer HID device terminated: %s, # devices: %d\n", getName(), path, attached_hid_pointer_devices->getCount());
+    }
+    
+    if (notifier == bluetooth_hid_publish_notify) {
+        bluetoothHIDAttached(newService, path);
+    }
+    
+    if (notifier == bluetooth_hid_terminate_notify) {
+        attached_hid_pointer_devices->removeObject(newService);
+        IOLog("%s: Bluetooth pointer HID device terminated: %s, # devices: %d\n", getName(), path, attached_hid_pointer_devices->getCount());
+    }
+}
+
+bool VoodooI2CKeyboardHIDEventDriver::notificationHIDAttachedHandler(void *refCon,
+                                                                     IOService *newService,
+                                                                     IONotifier *notifier) {
+    IOCommandGate::Action action = OSMemberFunctionCast(IOCommandGate::Action,
+                                                        this,
+                                                        &VoodooI2CKeyboardHIDEventDriver::notificationHIDAttachedHandlerGated);
+    
+    command_gate->runAction(action, newService, notifier);
+    return true;
+}

--- a/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.cpp
@@ -70,17 +70,18 @@ void VoodooI2CKeyboardHIDEventDriver::handleInterruptReport(AbsoluteTime timesta
                                                             UInt32 report_id) {
     UInt32      volumeHandled   = 0;
     UInt32      volumeState     = 0;
-    UInt32      index, count;
+    UInt32      maxElement;
     
     if(!keyboard.elements)
         return;
     
-    for (index=0, count=keyboard.elements->getCount(); index<count; index++) {
+    maxElement = keyboard.elements->getCount();
+    for (UInt32 i = 0; i < maxElement; i++) {
         IOHIDElement* element = nullptr;
         AbsoluteTime  elementTimeStamp;
         UInt32        usagePage, usage, value, preValue;
         
-        element = OSDynamicCast(IOHIDElement, keyboard.elements->getObject(index));
+        element = OSDynamicCast(IOHIDElement, keyboard.elements->getObject(i));
         if (!element)
             continue;
         
@@ -307,28 +308,30 @@ void VoodooI2CKeyboardHIDEventDriver::parseKeyboardElement(IOHIDElement *element
     }
 }
 
-    
+//Keyboard : Loop through all createMatchingElements() and parse KeyboardElements
 IOReturn VoodooI2CKeyboardHIDEventDriver::parseElements() {
-    //Keyboard : Loop through all createMatchingElements() and parse KeyboardElements
-        
     OSArray *elementArray = hid_interface->createMatchingElements();
     keyboard.appleVendorSupported = getProperty(kIOHIDAppleVendorSupported, gIOServicePlane);
-    if (elementArray) {
-        for (int i=0, count=elementArray->getCount(); i<count; i++) {
-            IOHIDElement* element   = nullptr;
-            
-            element = OSDynamicCast(IOHIDElement, elementArray->getObject(i));
-            if (!element)
-                continue;
-            
-            if (element->getType() == kIOHIDElementTypeCollection)
-                continue;
-            
-            if (element->getUsage() == 0)
-                continue;
-            
-            parseKeyboardElement(element);
-        }
+    
+    if (!elementArray) {
+        return kIOReturnSuccess;
+    }
+
+    int maxElement = elementArray->getCount();
+    for (int i = 0; i < maxElement; i++) {
+        IOHIDElement* element   = nullptr;
+        
+        element = OSDynamicCast(IOHIDElement, elementArray->getObject(i));
+        if (!element)
+            continue;
+        
+        if (element->getType() == kIOHIDElementTypeCollection)
+            continue;
+        
+        if (element->getUsage() == 0)
+            continue;
+        
+        parseKeyboardElement(element);
     }
     
     OSSafeReleaseNULL(elementArray);

--- a/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.cpp
@@ -68,9 +68,9 @@ void VoodooI2CKeyboardHIDEventDriver::handleInterruptReport(AbsoluteTime timesta
                                                             IOMemoryDescriptor *report,
                                                             IOHIDReportType report_type,
                                                             UInt32 report_id) {
-    UInt32      volumeHandled   = 0;
-    UInt32      volumeState     = 0;
-    UInt32      maxElement;
+    UInt32 volumeHandled = 0;
+    UInt32 volumeState = 0;
+    UInt32 maxElement;
     
     if(!keyboard.elements)
         return;
@@ -92,8 +92,8 @@ void VoodooI2CKeyboardHIDEventDriver::handleInterruptReport(AbsoluteTime timesta
         if (CMP_ABSOLUTETIME(&timestamp, &elementTimeStamp) != 0)
             continue;
         
-        preValue    = element->getValue(kIOHIDValueOptionsFlagPrevious) != 0;
-        value       = element->getValue() != 0;
+        preValue = element->getValue(kIOHIDValueOptionsFlagPrevious) != 0;
+        value = element->getValue() != 0;
         
         if (value == preValue)
             continue;
@@ -105,16 +105,16 @@ void VoodooI2CKeyboardHIDEventDriver::handleInterruptReport(AbsoluteTime timesta
             bool suppress = true;
             switch (usage) {
                 case kHIDUsage_Csmr_VolumeIncrement:
-                    volumeHandled   |= kHIDIncrVolume;
-                    volumeState     |= (value) ? kHIDIncrVolume:0;
+                    volumeHandled |= kHIDIncrVolume;
+                    volumeState |= (value) ? kHIDIncrVolume : 0;
                     break;
                 case kHIDUsage_Csmr_VolumeDecrement:
-                    volumeHandled   |= kHIDDecrVolume;
-                    volumeState     |= (value) ? kHIDDecrVolume:0;
+                    volumeHandled |= kHIDDecrVolume;
+                    volumeState |= (value) ? kHIDDecrVolume : 0;
                     break;
                 case kHIDUsage_Csmr_Mute:
-                    volumeHandled   |= kHIDMute;
-                    volumeState     |= (value) ? kHIDMute:0;
+                    volumeHandled |= kHIDMute;
+                    volumeState |= (value) ? kHIDMute : 0;
                     break;
                 default:
                     suppress = false;
@@ -131,8 +131,8 @@ void VoodooI2CKeyboardHIDEventDriver::handleInterruptReport(AbsoluteTime timesta
     // RY: Handle the case where Vol Increment, Decrement, and Mute are all down
     // If such an event occurs, it is likely that the device is defective,
     // and should be ignored.
-    if ((volumeState != (kHIDIncrVolume|kHIDDecrVolume|kHIDMute)) &&
-        (volumeHandled != (kHIDIncrVolume|kHIDDecrVolume|kHIDMute))) {
+    if ((volumeState != (kHIDIncrVolume | kHIDDecrVolume | kHIDMute)) &&
+        (volumeHandled != (kHIDIncrVolume | kHIDDecrVolume | kHIDMute))) {
         // Volume Increment
         if (volumeHandled & kHIDIncrVolume)
             dispatchKeyboardEvent(timestamp, kHIDPage_Consumer, kHIDUsage_Csmr_VolumeIncrement, ((volumeState & kHIDIncrVolume) != 0));
@@ -199,9 +199,9 @@ void VoodooI2CKeyboardHIDEventDriver::handleStop(IOService *provider) {
 }
 
 void VoodooI2CKeyboardHIDEventDriver::parseKeyboardElement(IOHIDElement *element) {
-    UInt32 usagePage    = element->getUsagePage();
-    UInt32 usage        = element->getUsage();
-    bool   store        = false;
+    UInt32 usagePage = element->getUsagePage();
+    UInt32 usage = element->getUsage();
+    bool store = false;
     
     if (!keyboard.elements) {
         keyboard.elements = OSArray::withCapacity(4);
@@ -243,8 +243,8 @@ void VoodooI2CKeyboardHIDEventDriver::parseKeyboardElement(IOHIDElement *element
             // user input is possible
             
             if (usage == kHIDUsage_KeyboardPower) {
-                OSDictionary* kbEnableEventProps    = NULL;
-                UInt32 value                        = 0;
+                OSDictionary* kbEnableEventProps = NULL;
+                UInt32 value = 0;
                 
                 // To avoid problems with un-intentional clearing of the flag
                 // we require this report to be a feature report so that the current
@@ -388,9 +388,6 @@ IOReturn VoodooI2CKeyboardHIDEventDriver::message(UInt32 type, IOService* provid
         {
             //  Remember last time key was pressed
             key_time = *((uint64_t*)argument);
-#if DEBUG
-            IOLog("%s::keyPressed = %llu\n", getName(), key_time);
-#endif
             break;
         }
     }

--- a/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.cpp
@@ -256,22 +256,22 @@ void VoodooI2CKeyboardHIDEventDriver::parseKeyboardElement(IOHIDElement *element
             // This usage is used to let the OS know if a keyboard is in an enabled state where
             // user input is possible
             
-            if (usage != kHIDUsage_KeyboardPower)
-                break;
-            
-            // To avoid problems with un-intentional clearing of the flag
-            // we require this report to be a feature report so that the current
-            // state can be polled if necessary
-            
-            if (element->getType() == kIOHIDElementTypeFeature) {
-                OSDictionary* kbEnableEventProps = OSDictionary::withCapacity(3);
-                if (!kbEnableEventProps)
-                    break;
-                OSSafeReleaseNULL(kbEnableEventProps);
-            }
+            if (usage == kHIDUsage_KeyboardPower) {
                 
-            store = true;
-            break;
+                // To avoid problems with un-intentional clearing of the flag
+                // we require this report to be a feature report so that the current
+                // state can be polled if necessary
+                
+                if (element->getType() == kIOHIDElementTypeFeature) {
+                    OSDictionary* kbEnableEventProps = OSDictionary::withCapacity(3);
+                    if (!kbEnableEventProps)
+                        break;
+                    OSSafeReleaseNULL(kbEnableEventProps);
+                }
+                
+                store = true;
+                break;
+            }
         case kHIDPage_Consumer:
             if (usage == kHIDUsage_Csmr_ACKeyboardLayoutSelect)
                 setProperty(kIOHIDSupportsGlobeKeyKey, kOSBooleanTrue);

--- a/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.cpp
@@ -2,7 +2,7 @@
 //  VoodooI2CKeyboardHIDEventDriver.cpp
 //  VoodooI2CHID
 //
-//  Created by 夏尚宁 on 2021/3/17.
+//  Created by Xiashangning on 2021/3/17.
 //  Copyright © 2021 Alexandre Daoud. All rights reserved.
 //
 

--- a/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.hpp
@@ -1,0 +1,206 @@
+//
+//  VoodooI2CKeyboardHIDEventDriver.hpp
+//  VoodooI2CHID
+//
+//  Created by 夏尚宁 on 2021/3/17.
+//  Copyright © 2021 Alexandre Daoud. All rights reserved.
+//
+
+#ifndef VoodooI2CKeyboardHIDEventDriver_hpp
+#define VoodooI2CKeyboardHIDEventDriver_hpp
+
+// hack to prevent IOHIDEventDriver from loading when
+// we include IOHIDEventService
+
+#define _IOKIT_HID_IOHIDEVENTDRIVER_H
+
+#include <libkern/OSBase.h>
+
+#include <IOKit/IOLib.h>
+#include <IOKit/IOKitKeys.h>
+#include <IOKit/IOService.h>
+
+#include <IOKit/hid/IOHIDEvent.h>
+#include <IOKit/hid/IOHIDEventService.h>
+#include <IOKit/hid/IOHIDEventTypes.h>
+#include <IOKit/hidsystem/IOHIDTypes.h>
+#include <IOKit/hid/IOHIDPrivateKeys.h>
+#include <IOKit/hid/IOHIDUsageTables.h>
+#include <IOKit/hid/IOHIDDevice.h>
+
+#include "../../../Dependencies/helpers.hpp"
+
+// Message types defined by ApplePS2Keyboard
+enum {
+    // from keyboard to mouse/touchpad
+    kKeyboardSetTouchStatus = iokit_vendor_specific_msg(100),   // set disable/enable touchpad (data is bool*)
+    kKeyboardGetTouchStatus = iokit_vendor_specific_msg(101),   // get disable/enable touchpad (data is bool*)
+    kKeyboardKeyPressTime = iokit_vendor_specific_msg(110)      // notify of timestamp a non-modifier key was pressed (data is uint64_t*)
+};
+
+/* Implements an HID Event Driver for HID devices that expose a digitiser usage page.
+ *
+ * The members of this class are responsible for parsing, processing and interpreting digitiser-related HID objects.
+ */
+
+class EXPORT VoodooI2CKeyboardHIDEventDriver : public IOHIDEventService {
+  OSDeclareDefaultStructors(VoodooI2CKeyboardHIDEventDriver);
+
+ public:
+    struct {
+            OSArray *           elements;
+            UInt8               bootMouseData[4];
+            bool                appleVendorSupported;
+    } keyboard;
+
+    /* Notification that a provider has been terminated, sent after recursing up the stack, in leaf-to-root order.
+     * @options The terminated provider of this object.
+     * @defer If there is pending I/O that requires this object to persist, and the provider is not opened by this object set defer to true and call the IOService::didTerminate() implementation when the I/O completes. Otherwise, leave defer set to its default value of false.
+     *
+     * @return *true*
+     */
+
+    bool didTerminate(IOService *provider, IOOptionBits options, bool *defer) override;
+
+    /*Gets the latest value of an element by issuing a getReport request to the
+     * device. Necessary due to changes between 10.11 and 10.12.
+     * @element The element whose vaue is to be updated
+     *
+     * @return The new value of the element
+     */
+    
+    UInt32 getElementValue(IOHIDElement* element);
+    
+    const char* getProductName();
+    
+    /* Called during the interrupt routine to handle an interrupt report
+     * @timestamp The timestamp of the interrupt report
+     * @report A buffer containing the report data
+     * @report_type The type of HID report
+     * @report_id The report ID of the interrupt report
+     */
+
+    virtual void handleInterruptReport(AbsoluteTime timestamp, IOMemoryDescriptor *report, IOHIDReportType report_type, UInt32 report_id);
+
+    /* Called during the start routine to set up the HID Event Driver
+     * @provider The <IOHIDInterface> object which we have matched against.
+     *
+     * This function is reponsible for opening a client connection with the <IOHIDInterface> provider and for publishing
+     * a multitouch interface into the IOService plane.
+     *
+     * @return *true* on successful start, *false* otherwise
+     */
+
+    bool handleStart(IOService *provider) override;
+    
+    
+    /* Parses a keyboard usage page element
+     * @element The element to parse
+     *
+     * This function is reponsible for examining the child elements of a digitser elements to determine the
+     * capabilities of the keyboard.
+     *
+     * @return *true* on successful parse, *false* otherwise
+     */
+
+    bool parseKeyboardElement(IOHIDElement *element);
+
+
+    /* Parses all matched elements
+     *
+     * @return *kIOReturnSuccess* on successful parse, *kIOReturnNotFound* if the matched elements are not supported, *kIOReturnError* otherwise
+     */
+
+    IOReturn parseElements();
+
+    
+    void setKeyboardProperties();
+
+    /* Called by the OS in order to notify the driver that the device should change power state
+     * @whichState The power state the device is expected to enter represented by either
+     *  *kIOPMPowerOn* or *kIOPMPowerOff*
+     * @whatDevice The power management policy maker
+     *
+     * This function exists to be overriden by inherited classes should they need it.
+     *
+     * @return *kIOPMAckImplied* on succesful state change, *kIOReturnError* otherwise
+     */
+
+    IOReturn setPowerState(unsigned long whichState, IOService *whatDevice) override;
+
+    /* Called during the stop routine to terminate the HID Event Driver
+     * @provider The <IOHIDInterface> object which we have matched against.
+     *
+     * This function is reponsible for releasing the resources allocated in <start>
+     */
+
+    void handleStop(IOService *provider) override;
+
+    /* Implemented to set a certain property
+     * @provider The <IOHIDInterface> object which we have matched against.
+     */
+
+    bool start(IOService *provider) override;
+    
+    /*
+     * Called by ApplePS2Controller to notify of keyboard interactions
+     * @type Custom message type in iokit_vendor_specific_msg range
+     * @provider Calling IOService
+     * @argument Optional argument as defined by message type
+     *
+     * @return kIOReturnSuccess if the message is processed
+     */
+    IOReturn message(UInt32 type, IOService *provider, void *argument) override;
+    
+    /*
+     * Used to pass user preferences from user mode to the driver
+     * @properties OSDictionary of configured properties
+     *
+     * @return kIOReturnSuccess if the properties are received successfully, otherwise kIOUnsupported
+     */
+    IOReturn setProperties(OSObject *properties) override;
+
+ protected:
+    const char* name;
+    bool awake = true;
+    IOHIDInterface* hid_interface;
+    IOHIDDevice* hid_device;
+
+ private:
+    IOWorkLoop* work_loop;
+    IOCommandGate* command_gate;
+    
+    uint64_t key_time = 0;
+    
+    OSSet* attached_hid_pointer_devices;
+    
+    IONotifier* usb_hid_publish_notify;     // Notification when an USB mouse HID device is connected
+    IONotifier* usb_hid_terminate_notify; // Notification when an USB mouse HID device is disconnected
+    
+    IONotifier* bluetooth_hid_publish_notify; // Notification when a bluetooth HID device is connected
+    IONotifier* bluetooth_hid_terminate_notify; // Notification when a bluetooth HID device is disconnected
+    
+    /*
+     * Helper function to help parse bluetooth device notifications
+     * @newService IOService object matching criteria for addMatchingNotification
+     * @path IOService path for newService
+     */
+    void bluetoothHIDAttached(IOService *newService, char *path);
+    
+    /*
+     * IOServiceMatchingNotificationHandler (gated) to receive notification of addMatchingNotification registrations
+     * @newService IOService object matching the criteria for the addMatchingNotification registration
+     * @notifier IONotifier object for the notification registration
+     */
+    void notificationHIDAttachedHandlerGated(IOService *newService, IONotifier *notifier);
+    
+    /*
+     * IOServiceMatchingNotificationHandler to receive notification of addMatchingNotification registrations
+     * @refCon reference set when registering
+     * @newService IOService object matching the criteria for the addMatchingNotification registration
+     * @notifier IONotifier object for the notification registration
+     */
+    bool notificationHIDAttachedHandler(void *refCon, IOService *newService, IONotifier *notifier);
+};
+
+#endif /* VoodooI2CKeyboardHIDEventDriver_hpp */

--- a/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.hpp
@@ -171,36 +171,6 @@ class EXPORT VoodooI2CKeyboardHIDEventDriver : public IOHIDEventService {
     IOCommandGate* command_gate;
     
     uint64_t key_time = 0;
-    
-    OSSet* attached_hid_pointer_devices;
-    
-    IONotifier* usb_hid_publish_notify;     // Notification when an USB mouse HID device is connected
-    IONotifier* usb_hid_terminate_notify; // Notification when an USB mouse HID device is disconnected
-    
-    IONotifier* bluetooth_hid_publish_notify; // Notification when a bluetooth HID device is connected
-    IONotifier* bluetooth_hid_terminate_notify; // Notification when a bluetooth HID device is disconnected
-    
-    /*
-     * Helper function to help parse bluetooth device notifications
-     * @newService IOService object matching criteria for addMatchingNotification
-     * @path IOService path for newService
-     */
-    void bluetoothHIDAttached(IOService *newService, char *path);
-    
-    /*
-     * IOServiceMatchingNotificationHandler (gated) to receive notification of addMatchingNotification registrations
-     * @newService IOService object matching the criteria for the addMatchingNotification registration
-     * @notifier IONotifier object for the notification registration
-     */
-    void notificationHIDAttachedHandlerGated(IOService *newService, IONotifier *notifier);
-    
-    /*
-     * IOServiceMatchingNotificationHandler to receive notification of addMatchingNotification registrations
-     * @refCon reference set when registering
-     * @newService IOService object matching the criteria for the addMatchingNotification registration
-     * @notifier IONotifier object for the notification registration
-     */
-    bool notificationHIDAttachedHandler(void *refCon, IOService *newService, IONotifier *notifier);
 };
 
 #endif /* VoodooI2CKeyboardHIDEventDriver_hpp */

--- a/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.hpp
@@ -2,7 +2,7 @@
 //  VoodooI2CKeyboardHIDEventDriver.hpp
 //  VoodooI2CHID
 //
-//  Created by 夏尚宁 on 2021/3/17.
+//  Created by Xiashangning on 2021/3/17.
 //  Copyright © 2021 Alexandre Daoud. All rights reserved.
 //
 

--- a/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CKeyboardHIDEventDriver.hpp
@@ -103,7 +103,7 @@ class EXPORT VoodooI2CKeyboardHIDEventDriver : public IOHIDEventService {
      * @return *true* on successful parse, *false* otherwise
      */
 
-    bool parseKeyboardElement(IOHIDElement *element);
+    void parseKeyboardElement(IOHIDElement *element);
 
 
     /* Parses all matched elements


### PR DESCRIPTION
Based off of https://github.com/shdkpr2008/VoodooI2CHID.git and https://github.com/VoodooI2C/VoodooI2CHID/pull/52
Cleaned up a bit (removed gotos, separated bluetooth HID attach to a different function)
Added IOMatchCategory, which should allow both the keyboard and touchpad to attach.

@Xiashangning do you mind testing?
I'd rather not split VoodooI2CHID, as that creates more confusion (especially for the dortania guides)
[VoodooI2CHID.kext.zip](https://github.com/VoodooI2C/VoodooI2CHID/files/6947148/VoodooI2CHID.kext.zip)
