### PR TITLE
Fix report parsing for devices with multi-mode (trackpad or touchscreen) capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# VoodooI2CHID
+
+This is a fork with a fix for the Precision Trackpad and Touch Screen Trackpad satellites to work correctly for devices that can work with multiple modes (trackpad or touch screen).
+
+An example of such a device would be the Screenpads in many ASUS laptops. 
+
+Without this fix, such devices only work in single finger mode.
+
+The root cause is in the parsing of the report descriptors to maintain a list of supproted elements to use when an input report is received. The original code assumed a single mode for any device. But this could result in incorrect caching of element objects for a record descriptor which contained common elements in multiple modes.
+
+The fix allows the Precision Trackpad and Touch Screen Event Drivers to narrow the parsing of record descriptors to their respective modes only.
+
+This has solved the multi-touch problem with Screenpad devices such as The Goodix GDX1515 amongst others.

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -431,7 +431,7 @@ bool VoodooI2CMultitouchHIDEventDriver::handleStart(IOService* provider) {
     if (!digitiser.transducers)
         return false;
 
-    if (parseElements() != kIOReturnSuccess) {
+    if (parseElements(0) != kIOReturnSuccess) {
         IOLog("%s::%s Could not parse multitouch elements\n", getName(), name);
         return false;
     }
@@ -597,7 +597,7 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::parseDigitizerElement(IOHIDElement* 
     return kIOReturnSuccess;
 }
     
-IOReturn VoodooI2CMultitouchHIDEventDriver::parseElements() {
+IOReturn VoodooI2CMultitouchHIDEventDriver::parseElements(UInt32 forUsage) {
     int index, count;
 
     OSArray* supported_elements = OSDynamicCast(OSArray, hid_device->getProperty(kIOHIDElementKey));
@@ -615,16 +615,24 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::parseElements() {
         if (element->getUsage() == 0)
             continue;
 
-        if (element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_Pen)
-            || element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_TouchScreen)
-            || element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_TouchPad)
-            || element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_DeviceConfiguration)
-            )
-            parseDigitizerElement(element);
-        
-        if (multitouch_interface && element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_TouchScreen))
-            multitouch_interface->setProperty(kIOHIDDisplayIntegratedKey, kOSBooleanTrue);
+        if (forUsage) {
+            if (element->conformsTo(kHIDPage_Digitizer, forUsage)
+                || element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_DeviceConfiguration)
+                )
+                parseDigitizerElement(element);
+        } else {
+            if (element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_Pen)
+                || element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_TouchScreen)
+                || element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_TouchPad)
+                || element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_DeviceConfiguration)
+                )
+                parseDigitizerElement(element);
+            }
+        if (!forUsage || (forUsage == kHIDUsage_Dig_TouchScreen)) {
+            if (multitouch_interface && element->conformsTo(kHIDPage_Digitizer, kHIDUsage_Dig_TouchScreen))
+                multitouch_interface->setProperty(kIOHIDDisplayIntegratedKey, kOSBooleanTrue);
         }
+    }
     
 
     if (digitiser.styluses->getCount() == 0 && digitiser.fingers->getCount() == 0)

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
@@ -178,13 +178,7 @@ class EXPORT VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
 
     IOReturn parseDigitizerTransducerElement(IOHIDElement* element, IOHIDElement* parent);
 
-    /* Parses all matched elements
-     *
-     * @return *kIOReturnSuccess* on successful parse, *kIOReturnNotFound* if the matched elements are not supported, *kIOReturnError* otherwise
-     */
-
-    IOReturn parseElements();
-
+    
     /* Postprocessing of digitizer elements
      *
      * This function is mostly copied from Apple's own HID Event Driver code. It is responsible for cleaning up malformed report descriptors as well as setting some miscellaneous properties.
@@ -266,6 +260,13 @@ class EXPORT VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
     bool should_have_interface = true;
 
     virtual void forwardReport(VoodooI2CMultitouchEvent event, AbsoluteTime timestamp);
+    
+    /* Parses all matched elements
+     *
+     * @return *kIOReturnSuccess* on successful parse, *kIOReturnNotFound* if the matched elements are not supported, *kIOReturnError* otherwise
+     */
+
+    virtual IOReturn parseElements(UInt32 forUsage=0);
 
  private:
     SInt32 absolute_axis_removal_percentage = 15;

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
@@ -49,6 +49,10 @@ bool VoodooI2CPrecisionTouchpadHIDEventDriver::handleStart(IOService* provider) 
     return true;
 }
 
+IOReturn VoodooI2CPrecisionTouchpadHIDEventDriver::parseElements(UInt32) {
+    return super::parseElements(kHIDUsage_Dig_TouchPad);
+}
+
 IOReturn VoodooI2CPrecisionTouchpadHIDEventDriver::setPowerState(unsigned long whichState, IOService* whatDevice) {
     if (whatDevice != this)
         return kIOReturnInvalid;

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.hpp
@@ -49,6 +49,7 @@ class EXPORT VoodooI2CPrecisionTouchpadHIDEventDriver : public VoodooI2CMultitou
     IOReturn setPowerState(unsigned long whichState, IOService* whatDevice) override;
 
  protected:
+    IOReturn parseElements(UInt32 forUsage=0) override;
  private:
     bool ready = false;
 

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -111,6 +111,10 @@ void VoodooI2CTouchscreenHIDEventDriver::checkRotation(IOFixed* x, IOFixed* y) {
     }
 }
 
+IOReturn VoodooI2CTouchscreenHIDEventDriver::parseElements(UInt32) {
+    return super::parseElements(kHIDUsage_Dig_TouchScreen);
+}
+
 bool VoodooI2CTouchscreenHIDEventDriver::checkStylus(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event) {
     //  Check the current transducers for stylus operation, dispatch the pointer events and return true.
     //  At this time, Apple has removed all methods of handling additional information from the event driver.  Only x, y, buttonstate, and

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -56,6 +56,7 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      */
 
     bool checkStylus(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event);
+    IOReturn parseElements(UInt32 forUsage=0) override;
 
  private:
     IOWorkLoop *work_loop;


### PR DESCRIPTION
This provides a fix for correctly parsing the report descriptor for the desired mode in a multi-mode device such as the Asus Screenpad (e.g., as trackpad or as touch screen).

In such devices the same elements (e.g., contact count) can exist in multiple sections in the report descriptor. While parsing the report descriptor, the current code assumes a single mode and parses all elements that can work in any mode. Depending on the order in which the record descriptor elements are parsed, the wrong object may be cached for reporting for the mode in which the satellite driver is using the device in. 

This results in symptoms such as multi-touch not being available for such a device as the contact count element object cached may be for the wrong mode for the mode in which the device is being used. That cached object will then not update as reports come in for the device in desired mode.

The fix allows the specialized device event drivers such as PrecisionTrackpad or TouchScreen to control the parsing and caching for their respective modes only.

This fix has no known side-effects (not tested with pen/stylus capability) and has fixed multi-touch unavailability problem for the Asus Screenpad working as a trackpad and the second screen of Asus Duo laptops working as touch screen.