### PR TITLE
Add report ID to set input mode command, revert input_mode->setValue

### DIFF
--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
@@ -12,9 +12,15 @@
 OSDefineMetaClassAndStructors(VoodooI2CPrecisionTouchpadHIDEventDriver, VoodooI2CMultitouchHIDEventDriver);
 
 void VoodooI2CPrecisionTouchpadHIDEventDriver::enterPrecisionTouchpadMode() {
-    // We should really do this using `input_mode_element->setValue(INPUT_MODE_TOUCHPAD)`.
-    // This appears to not work on Catalina or older though (Works in Big Sur/Monterey)
+    if (version_major > CATALINA_MAJOR_VERSION) {
+        // Update value from hardware so we can rewrite mode when waking from sleep
+        digitiser.input_mode->getValue(kIOHIDValueOptionsUpdateElementValues);
+        digitiser.input_mode->setValue(INPUT_MODE_TOUCHPAD);
+        ready = true;
+        return;
+    }
     
+    // TODO: setValue appears to not work on Catalina or older
     VoodooI2CPrecisionTouchpadFeatureReport buffer;
     buffer.reportID = digitiser.input_mode->getReportID();
     buffer.value = INPUT_MODE_TOUCHPAD;

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
@@ -12,8 +12,19 @@
 OSDefineMetaClassAndStructors(VoodooI2CPrecisionTouchpadHIDEventDriver, VoodooI2CMultitouchHIDEventDriver);
 
 void VoodooI2CPrecisionTouchpadHIDEventDriver::enterPrecisionTouchpadMode() {
-    digitiser.input_mode->setValue(INPUT_MODE_TOUCHPAD);
+    // We should really do this using `input_mode_element->setValue(INPUT_MODE_TOUCHPAD)`.
+    // This appears to not work on Catalina or older though (Works in Big Sur/Monterey)
+    
+    VoodooI2CPrecisionTouchpadFeatureReport buffer;
+    buffer.reportID = digitiser.input_mode->getReportID();
+    buffer.value = INPUT_MODE_TOUCHPAD;
+    buffer.reserved = 0x00;
+    IOBufferMemoryDescriptor* report = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, sizeof(VoodooI2CPrecisionTouchpadFeatureReport));
+    report->writeBytes(0, &buffer, sizeof(VoodooI2CPrecisionTouchpadFeatureReport));
 
+    hid_interface->setReport(report, kIOHIDReportTypeFeature, digitiser.input_mode->getReportID());
+    report->release();
+    
     ready = true;
 }
 

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.hpp
@@ -24,7 +24,7 @@
 #define INPUT_MODE_MOUSE 0x00
 #define INPUT_MODE_TOUCHPAD 0x03
 
-#define CATALINA_MAJOR_VERSION 20 // Darwin major version for Catalina
+#define CATALINA_MAJOR_VERSION 19 // Darwin major version for Catalina
 
 typedef struct __attribute__((__packed__)) {
      UInt8 reportID;

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.hpp
@@ -10,6 +10,7 @@
 #define VoodooI2CPrecisionTouchpadHIDEventDriver_hpp
 
 #include <IOKit/IOLib.h>
+#include <libkern/version.h>
 #include <IOKit/IOKitKeys.h>
 #include <IOKit/IOService.h>
 #include <IOKit/IOBufferMemoryDescriptor.h>
@@ -22,6 +23,8 @@
 
 #define INPUT_MODE_MOUSE 0x00
 #define INPUT_MODE_TOUCHPAD 0x03
+
+#define CATALINA_MAJOR_VERSION 20 // Darwin major version for Catalina
 
 typedef struct __attribute__((__packed__)) {
      UInt8 reportID;

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.hpp
@@ -23,6 +23,12 @@
 #define INPUT_MODE_MOUSE 0x00
 #define INPUT_MODE_TOUCHPAD 0x03
 
+typedef struct __attribute__((__packed__)) {
+     UInt8 reportID;
+     UInt8 value;
+     UInt8 reserved;
+ } VoodooI2CPrecisionTouchpadFeatureReport;
+
 /* Implements an HID Event Driver for Precision Touchpad devices as specified by Microsoft's protocol in the following document: https://docs.microsoft.com/en-us/windows-hardware/design/component-guidelines/precision-touchpad-devices
  *
  * The members of this class are responsible for instructing a Precision Touchpad device to enter Touchpad mode.


### PR DESCRIPTION
This should still work with USB devices since the format was fixed.

input_mode->SetValue seems to break completely with I2C on Catalina. I wasn't able to figure out why it was broken, but this was reported to work. User's input mode report had an id of 3 (same value as Touchpad mode). It would be good to see if this works with USB devices.
~~[VoodooI2CHID+reportID.zip](https://github.com/VoodooI2C/VoodooI2CHID/files/8119470/VoodooI2CHID%2BreportID.zip)~~
[VoodooI2CHID+CondReportID.zip](https://github.com/VoodooI2C/VoodooI2CHID/files/8128272/VoodooI2CHID%2BCondReportID.zip)

