### PR TITLE
Commented out problematic enterPrecisionTouchpadMode I2C command

### DIFF
--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -89,6 +89,10 @@
 					<integer>13</integer>
 				</dict>
 			</array>
+			<dict>
+				<key>Transport</key>
+				<string>I2C</string>
+			</dict>
 			<key>IOProbeScore</key>
 			<integer>300</integer>
 			<key>IOClass</key>

--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -89,6 +89,7 @@
 					<integer>13</integer>
 				</dict>
 			</array>
+			<key>IOPropertyMatch</key>
 			<dict>
 				<key>Transport</key>
 				<string>I2C</string>

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
@@ -12,13 +12,17 @@
 OSDefineMetaClassAndStructors(VoodooI2CPrecisionTouchpadHIDEventDriver, VoodooI2CMultitouchHIDEventDriver);
 
 void VoodooI2CPrecisionTouchpadHIDEventDriver::enterPrecisionTouchpadMode() {
-    if (version_major > CATALINA_MAJOR_VERSION) {
+    // This needs to be investigated further for USB touchpad support,
+    // it is currently commented out as it causes issues with input devices
+    // failing to wake from sleep and does not work on 10.15 and lower
+
+    /* if (version_major > CATALINA_MAJOR_VERSION) {
         // Update value from hardware so we can rewrite mode when waking from sleep
         digitiser.input_mode->getValue(kIOHIDValueOptionsUpdateElementValues);
         digitiser.input_mode->setValue(INPUT_MODE_TOUCHPAD);
         ready = true;
         return;
-    }
+    }*/
     
     // TODO: setValue appears to not work on Catalina or older
     VoodooI2CPrecisionTouchpadFeatureReport buffer;


### PR DESCRIPTION
Numerous users are reporting that
`digitiser.input_mode->setValue(INPUT_MODE_TOUCHPAD);` causes trackpads not to function after wake from sleep.