### PR TITLE
1. Always pass buttons as pressure on single-button touchpads (fix #496)

### DIFF
--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -179,6 +179,7 @@ void VoodooI2CMultitouchHIDEventDriver::handleDigitizerReport(AbsoluteTime times
         if (transducer) {
             setButtonState(&transducer->physical_button, 0, digitiser.primaryButton->getValue(), timestamp);
             if (digitiser.secondaryButton) {
+                transducer->has_secondary_button = true;
                 setButtonState(&transducer->physical_button, 1, digitiser.secondaryButton->getValue(), timestamp);
             }
         }


### PR DESCRIPTION
2. Always disable Force Touch and pass buttons to buttons device on touchpads with two physical buttons (fixes inability to click without finger on the touchpad (#499) and inability to use the right button with default settings)
3. Disable Force Touch on all touchpads if tap to click is disabled (fixes inability to make a non-force click with default settings, especially in Recovery where there is no System Preferences application)