### PR TITLE
Working double click for touchscreens

### DIFF
--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -358,10 +358,11 @@ void VoodooI2CTouchscreenHIDEventDriver::scrollPosition(AbsoluteTime timestamp, 
 }
 
 bool VoodooI2CTouchscreenHIDEventDriver::isCloseToLastClick(IOFixed x, IOFixed y) {
-    return (
-        abs(x - last_click_x) <= DOUBLE_CLICK_FAT_ZONE &&
-        abs(y - last_click_y) <= DOUBLE_CLICK_FAT_ZONE
-    );
+    IOFixed diff_x = x - last_click_x;
+    IOFixed diff_y = y - last_click_y;
+    return  (diff_x * diff_x) +
+            (diff_y * diff_y) <
+            FAT_FINGER_ZONE;
 }
 
 void VoodooI2CTouchscreenHIDEventDriver::scheduleLift() {

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -78,7 +78,7 @@ bool VoodooI2CTouchscreenHIDEventDriver::checkFingerTouch(AbsoluteTime timestamp
             //  executing a drag movement.  There is little noticeable affect in other circumstances.  This also assists in transitioning
             //  between single / multitouch.
             
-            if (click_tick < 1) {
+            if (click_tick <= 2) {
                 buttons = HOVER;
                 click_tick++;
             } else {

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -193,22 +193,15 @@ void VoodooI2CTouchscreenHIDEventDriver::fingerLift() {
     clock_get_uptime(&now_abs);
     
     if (do_double_click) {
-        // End the currently in progress click by hovering at 0
-        // This probably causes problems, but at least it prevents a proper click
-        dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, HOVER, 0, 0);
-
-        // Go where we last clicked
-        last_x = last_click_x;
-        last_y = last_click_y;
-
-        // Click twice
-        dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, LEFT_CLICK, last_x, last_y);
+        // Execute the current in progress click
         dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, HOVER, last_x, last_y);
+        IOLog("%s::Finger lift at %d, %d\n", getName(), last_x, last_y);
+
+        // Click again
         dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, LEFT_CLICK, last_x, last_y);
+        IOLog("%s::Left click at %d, %d\n", getName(), last_x, last_y);
+
         do_double_click = false;
-
-        IOLog("%s::Double click at %d, %d\n", getName(), last_x, last_y);
-
         last_click_time = 0;
     }
     else {
@@ -219,7 +212,6 @@ void VoodooI2CTouchscreenHIDEventDriver::fingerLift() {
     }
 
     dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, HOVER, last_x, last_y);
-    
     IOLog("%s::Finger lift at %d, %d\n", getName(), last_x, last_y);
     
     //  If a right click has been executed, we reset our counter and ensure that pointer is not stuck in right

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -12,14 +12,6 @@
 
 OSDefineMetaClassAndStructors(VoodooI2CTouchscreenHIDEventDriver, VoodooI2CMultitouchHIDEventDriver);
 
-static uint64_t millis() {
-    AbsoluteTime timestamp;
-    uint64_t nanoseconds;
-    clock_get_uptime(&timestamp);
-    absolutetime_to_nanoseconds(timestamp, &nanoseconds);
-    return nanoseconds / 1000000;
-}
-
 // Override of VoodooI2CMultitouchHIDEventDriver
 
 bool VoodooI2CTouchscreenHIDEventDriver::checkFingerTouch(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event) {
@@ -87,10 +79,14 @@ bool VoodooI2CTouchscreenHIDEventDriver::checkFingerTouch(AbsoluteTime timestamp
             if (right_click)
                 buttons = RIGHT_CLICK;
             
+            // Get time in a usable format
+            uint64_t nanoseconds;
+            absolutetime_to_nanoseconds(timestamp, &nanoseconds);
+
             // If we're clicking again where we just clicked, precisely position the pointer where it was before
             if (
                 isCloseToLastClick(x, y) &&
-                (millis() - last_click_time) <= DOUBLE_CLICK_TIME
+                (nanoseconds - last_click_time) <= DOUBLE_CLICK_TIME
             ) {
                 x = last_click_x;
                 y = last_click_y;
@@ -205,7 +201,7 @@ void VoodooI2CTouchscreenHIDEventDriver::fingerLift() {
         right_click = false;
     }
     
-    last_click_time = millis();
+    last_click_time = now_abs;
     last_click_x = last_x;
     last_click_y = last_y;
 }

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -94,6 +94,7 @@ bool VoodooI2CTouchscreenHIDEventDriver::checkFingerTouch(AbsoluteTime timestamp
 
             dispatchDigitizerEventWithTiltOrientation(timestamp, transducer->secondary_id, transducer->type, 0x1, buttons, x, y);
 
+ #ifdef VOODOO_I2C_TOUCHSCREEN_DEBUG
             if (buttons == HOVER) {
                 IOLog("%s::Hover at %d, %d\n", getName(), x, y);
             }
@@ -103,6 +104,7 @@ bool VoodooI2CTouchscreenHIDEventDriver::checkFingerTouch(AbsoluteTime timestamp
             else if (buttons == RIGHT_CLICK) {
                 IOLog("%s::Right click at %d, %d\n", getName(), x, y);
             }
+#endif
 
             // Track last ID and coordinates so that we can send the finger lift event after our watch dog timeout.
             last_x = x;
@@ -170,7 +172,9 @@ bool VoodooI2CTouchscreenHIDEventDriver::checkStylus(AbsoluteTime timestamp, Voo
             
             dispatchDigitizerEventWithTiltOrientation(timestamp, stylus->secondary_id, stylus->type, stylus->in_range, stylus_buttons, x, y, z, stylus_pressure, stylus->barrel_pressure.value(), stylus->azi_alti_orientation.twist.value(), stylus->tilt_orientation.x_tilt.value(), stylus->tilt_orientation.y_tilt.value());
             
+#ifdef VOODOO_I2C_TOUCHSCREEN_DEBUG
             IOLog("%s::Stylus at %d, %d\n", getName(), x, y);
+#endif
 
             return true;
         }
@@ -192,7 +196,9 @@ void VoodooI2CTouchscreenHIDEventDriver::fingerLift() {
     clock_get_uptime(&now_abs);
 
     dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, HOVER, last_x, last_y);
+#ifdef VOODOO_I2C_TOUCHSCREEN_DEBUG
     IOLog("%s::Finger lift at %d, %d\n", getName(), last_x, last_y);
+#endif
     
     //  If a right click has been executed, we reset our counter and ensure that pointer is not stuck in right
     //  click button down situation.
@@ -333,7 +339,9 @@ void VoodooI2CTouchscreenHIDEventDriver::scrollPosition(AbsoluteTime timestamp, 
         checkRotation(&cursor_x, &cursor_y);
         
         dispatchDigitizerEventWithTiltOrientation(timestamp, transducer->secondary_id, transducer->type, 0x1, HOVER, cursor_x, cursor_y);
+#ifdef VOODOO_I2C_TOUCHSCREEN_DEBUG
         IOLog("%s::Hover for scroll at %d, %d\n", getName(), cursor_x, cursor_y);
+#endif
 
         last_x = cursor_x;
         last_y = cursor_y;

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -89,7 +89,7 @@ bool VoodooI2CTouchscreenHIDEventDriver::checkFingerTouch(AbsoluteTime timestamp
             
             // If we're clicking again where we just clicked, precisely position the pointer where it was before
             if (
-                isCloseToLastInteraction(x, y) &&
+                isCloseToLastClick(x, y) &&
                 (millis() - last_click_time) <= DOUBLE_CLICK_TIME
             ) {
                 x = last_click_x;
@@ -349,7 +349,7 @@ void VoodooI2CTouchscreenHIDEventDriver::scrollPosition(AbsoluteTime timestamp, 
     scheduleLift();
 }
 
-bool VoodooI2CTouchscreenHIDEventDriver::isCloseToLastInteraction(IOFixed x, IOFixed y) {
+bool VoodooI2CTouchscreenHIDEventDriver::isCloseToLastClick(IOFixed x, IOFixed y) {
     return (
         abs(x - last_click_x) <= DOUBLE_CLICK_FAT_ZONE &&
         abs(y - last_click_y) <= DOUBLE_CLICK_FAT_ZONE

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -96,18 +96,6 @@ bool VoodooI2CTouchscreenHIDEventDriver::checkFingerTouch(AbsoluteTime timestamp
             // Only dispatch a single click event after we've done our hover ticks
             if ((click_tick <= HOVER_TICKS + 1) || (x != last_x || y != last_y)) {
                 dispatchDigitizerEventWithTiltOrientation(timestamp, transducer->secondary_id, transducer->type, 0x1, buttons, x, y);
-
-#ifdef VOODOO_I2C_TOUCHSCREEN_DEBUG
-               if (buttons == HOVER) {
-                   IOLog("%s::Hover at %d, %d\n", getName(), x, y);
-               }
-               else if (buttons == LEFT_CLICK) {
-                   IOLog("%s::Left click at %d, %d\n", getName(), x, y);
-               }
-               else if (buttons == RIGHT_CLICK) {
-                   IOLog("%s::Right click at %d, %d\n", getName(), x, y);
-               }
-#endif
             }
 
             // Track last ID and coordinates so that we can send the finger lift event after our watch dog timeout.
@@ -175,10 +163,6 @@ bool VoodooI2CTouchscreenHIDEventDriver::checkStylus(AbsoluteTime timestamp, Voo
             }
             
             dispatchDigitizerEventWithTiltOrientation(timestamp, stylus->secondary_id, stylus->type, stylus->in_range, stylus_buttons, x, y, z, stylus_pressure, stylus->barrel_pressure.value(), stylus->azi_alti_orientation.twist.value(), stylus->tilt_orientation.x_tilt.value(), stylus->tilt_orientation.y_tilt.value());
-            
-#ifdef VOODOO_I2C_TOUCHSCREEN_DEBUG
-            IOLog("%s::Stylus at %d, %d\n", getName(), x, y);
-#endif
 
             return true;
         }
@@ -200,9 +184,6 @@ void VoodooI2CTouchscreenHIDEventDriver::fingerLift() {
     clock_get_uptime(&now_abs);
 
     dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, HOVER, last_x, last_y);
-#ifdef VOODOO_I2C_TOUCHSCREEN_DEBUG
-    IOLog("%s::Finger lift at %d, %d\n", getName(), last_x, last_y);
-#endif
     
     //  If a right click has been executed, we reset our counter and ensure that pointer is not stuck in right
     //  click button down situation.
@@ -343,9 +324,6 @@ void VoodooI2CTouchscreenHIDEventDriver::scrollPosition(AbsoluteTime timestamp, 
         checkRotation(&cursor_x, &cursor_y);
         
         dispatchDigitizerEventWithTiltOrientation(timestamp, transducer->secondary_id, transducer->type, 0x1, HOVER, cursor_x, cursor_y);
-#ifdef VOODOO_I2C_TOUCHSCREEN_DEBUG
-        IOLog("%s::Hover for scroll at %d, %d\n", getName(), cursor_x, cursor_y);
-#endif
 
         last_x = cursor_x;
         last_y = cursor_y;

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -365,6 +365,5 @@ bool VoodooI2CTouchscreenHIDEventDriver::isCloseToLastClick(IOFixed x, IOFixed y
 }
 
 void VoodooI2CTouchscreenHIDEventDriver::scheduleLift() {
-    timer_source->cancelTimeout();
     timer_source->setTimeoutMS(FINGER_LIFT_DELAY);
 }

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -29,6 +29,7 @@
 #define DOUBLE_CLICK_FAT_ZONE   1000
 #define DOUBLE_CLICK_TIME       450 * 1000000
 #define FINGER_LIFT_DELAY       50
+#define HOVER_TICKS             3
 
 #define HOVER       0x0
 #define LEFT_CLICK  0x1
@@ -104,7 +105,7 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     /* handler variables
      */
     
-    int click_tick = 0;
+    UInt32 click_tick = 0;
     bool right_click = false;
     bool start_scroll = true;
     UInt16 compare_input_x = 0;

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -24,7 +24,7 @@
 
 #include "VoodooI2CMultitouchHIDEventDriver.hpp"
 
-#define VOODOO_I2C_TOUCHSCREEN_DEBUG
+// #define VOODOO_I2C_TOUCHSCREEN_DEBUG
 
 #define DOUBLE_CLICK_FAT_ZONE   1000
 #define DOUBLE_CLICK_TIME       450 * 1000000

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -111,7 +111,6 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     UInt16 compare_input_y = 0;
     int compare_input_counter = 0;
     UInt64 last_click_time = 0;
-    bool do_double_click = false;
     
     /* The transducer is checked for singletouch finger based operation and the pointer event dispatched. This function
      * also handles a long-press, right-click function.

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -75,7 +75,7 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
 
     /* Check if this interaction is within fat finger distance
      */
-    bool isCloseToLastInteraction(IOFixed x, IOFixed y);
+    bool isCloseToLastClick(IOFixed x, IOFixed y);
 
     /* Schedule a finger lift event
      */

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -26,10 +26,10 @@
 
 // #define VOODOO_I2C_TOUCHSCREEN_DEBUG
 
-#define DOUBLE_CLICK_FAT_ZONE   1000
-#define DOUBLE_CLICK_TIME       450 * 1000000
-#define FINGER_LIFT_DELAY       50
-#define HOVER_TICKS             3
+#define FAT_FINGER_ZONE     1000000 // 1000^2
+#define DOUBLE_CLICK_TIME   450 * 1000000
+#define FINGER_LIFT_DELAY   50
+#define HOVER_TICKS         3
 
 #define HOVER       0x0
 #define LEFT_CLICK  0x1

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -24,6 +24,17 @@
 
 #include "VoodooI2CMultitouchHIDEventDriver.hpp"
 
+#define VOODOO_I2C_TOUCHSCREEN_DEBUG
+
+#define DOUBLE_CLICK_FAT_ZONE   40
+#define DOUBLE_CLICK_TIME       450
+#define FINGER_LIFT_DELAY       50
+
+#define HOVER       0x0
+#define LEFT_CLICK  0x1
+#define RIGHT_CLICK 0x2
+#define ERASE       0x4
+
 /* Implements an HID Event Driver for touchscreen devices as well as stylus input.
  */
 
@@ -62,6 +73,14 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      */
     IOReturn parseElements(UInt32) override;
 
+    /* Check if this interaction is within fat finger distance
+     */
+    bool isCloseToLastInteraction(UInt16 x, UInt16 y);
+
+    /* Schedule a finger lift event
+     */
+    void scheduleLift();
+
  private:
     IOWorkLoop *work_loop;
     IOTimerEventSource *timer_source;
@@ -89,6 +108,7 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     UInt16 compare_input_x = 0;
     UInt16 compare_input_y = 0;
     int compare_input_counter = 0;
+    UInt64 last_click_time = 0;
     
     /* The transducer is checked for singletouch finger based operation and the pointer event dispatched. This function
      * also handles a long-press, right-click function.

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -27,7 +27,7 @@
 #define VOODOO_I2C_TOUCHSCREEN_DEBUG
 
 #define DOUBLE_CLICK_FAT_ZONE   1000
-#define DOUBLE_CLICK_TIME       450
+#define DOUBLE_CLICK_TIME       450 * 1000000
 #define FINGER_LIFT_DELAY       50
 
 #define HOVER       0x0

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -24,8 +24,6 @@
 
 #include "VoodooI2CMultitouchHIDEventDriver.hpp"
 
-// #define VOODOO_I2C_TOUCHSCREEN_DEBUG
-
 #define FAT_FINGER_ZONE     1000000 // 1000^2
 #define DOUBLE_CLICK_TIME   450 * 1000000
 #define FINGER_LIFT_DELAY   50

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -26,7 +26,7 @@
 
 #define VOODOO_I2C_TOUCHSCREEN_DEBUG
 
-#define DOUBLE_CLICK_FAT_ZONE   40
+#define DOUBLE_CLICK_FAT_ZONE   1000
 #define DOUBLE_CLICK_TIME       450
 #define FINGER_LIFT_DELAY       50
 
@@ -75,7 +75,7 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
 
     /* Check if this interaction is within fat finger distance
      */
-    bool isCloseToLastInteraction(UInt16 x, UInt16 y);
+    bool isCloseToLastInteraction(IOFixed x, IOFixed y);
 
     /* Schedule a finger lift event
      */
@@ -95,6 +95,8 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     UInt32 stylus_buttons = 0;
     IOFixed last_x = 0;
     IOFixed last_y = 0;
+    IOFixed last_click_x = 0;
+    IOFixed last_click_y = 0;
     UInt32 barrel_switch_offset = 0;
     UInt32 eraser_switch_offset = 0;
     SInt32 last_id = 0;
@@ -109,6 +111,7 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     UInt16 compare_input_y = 0;
     int compare_input_counter = 0;
     UInt64 last_click_time = 0;
+    bool do_double_click = false;
     
     /* The transducer is checked for singletouch finger based operation and the pointer event dispatched. This function
      * also handles a long-press, right-click function.


### PR DESCRIPTION
This PR enables working double click for touchscreens, such as the ELAN touchscreen on the Microsoft Surface Go 2.

Now you can double click through folders in the Finder with ease, or double click on words to select the word.

In addition to enabling double click, this PR also introduces a method to schedule a lift and adds a constant to define the time to wait between lifts. I increased this value from 14ms to 50ms, which seemed more forgiving when I was working on VoodooI2CGoodix and helps to prevent phantom clicks.

I also cleaned up some of the constants used for click types.

## Todo
* [x] I did notice that selecting a word by double clicking sometimes results in a triple click, so there may be some room for improvement here
* [x] I'm not sure the `millis()` function is needed, I might be able to use `timestamp` instead
* [x] I'm not sure if `cancelTimeout()` is needed in `scheduleLift` -- this was something I did in VoodooI2CGoodix
* [x] Implement a better distance algorithm?