### PR TITLE
Easier to use right click interaction for touchscreens

### DIFF
--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -62,13 +62,7 @@ bool VoodooI2CTouchscreenHIDEventDriver::checkFingerTouch(AbsoluteTime timestamp
             ) {
                 right_click = true;
                 dispatchDigitizerEventWithTiltOrientation(timestamp, transducer->secondary_id, transducer->type, 0x1, RIGHT_CLICK, x, y);
-#ifdef VOODOO_I2C_TOUCHSCREEN_DEBUG
-                IOLog("%s::Right click at %d, %d\n", getName(), x, y);
-#endif
                 dispatchDigitizerEventWithTiltOrientation(timestamp, transducer->secondary_id, transducer->type, 0x1, HOVER, x, y);
-#ifdef VOODOO_I2C_TOUCHSCREEN_DEBUG
-                IOLog("%s::Hover at %d, %d\n", getName(), x, y);
-#endif
             }
             else {
                 buttons = transducer->tip_switch.value();

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -10,6 +10,16 @@
 
 #define super VoodooI2CMultitouchHIDEventDriver
 
+/* Check if the first set of coordinates is within fat finger distance of the second set
+ */
+static bool isCloseTo(IOFixed x, IOFixed y, IOFixed other_x, IOFixed other_y) {
+   IOFixed diff_x = x - other_x;
+   IOFixed diff_y = y - other_y;
+   return  (diff_x * diff_x) +
+           (diff_y * diff_y) <
+           FAT_FINGER_ZONE;
+}
+
 OSDefineMetaClassAndStructors(VoodooI2CTouchscreenHIDEventDriver, VoodooI2CMultitouchHIDEventDriver);
 
 // Override of VoodooI2CMultitouchHIDEventDriver
@@ -332,14 +342,6 @@ void VoodooI2CTouchscreenHIDEventDriver::scrollPosition(AbsoluteTime timestamp, 
     }
     
     scheduleLift();
-}
-
-bool VoodooI2CTouchscreenHIDEventDriver::isCloseTo(IOFixed x, IOFixed y, IOFixed other_x, IOFixed other_y) {
-    IOFixed diff_x = x - other_x;
-    IOFixed diff_y = y - other_y;
-    return  (diff_x * diff_x) +
-            (diff_y * diff_y) <
-            FAT_FINGER_ZONE;
 }
 
 void VoodooI2CTouchscreenHIDEventDriver::scheduleLift() {

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -26,6 +26,7 @@
 
 #define FAT_FINGER_ZONE     1000000 // 1000^2
 #define DOUBLE_CLICK_TIME   450 * 1000000
+#define RIGHT_CLICK_TIME    500 * 1000000
 #define FINGER_LIFT_DELAY   50
 #define HOVER_TICKS         3
 
@@ -72,9 +73,9 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      */
     IOReturn parseElements(UInt32) override;
 
-    /* Check if this interaction is within fat finger distance
+    /* Check if the first set of coordinate is within fat finger distance of the second set
      */
-    bool isCloseToLastClick(IOFixed x, IOFixed y);
+    bool isCloseTo(IOFixed x, IOFixed y, IOFixed other_x, IOFixed other_y);
 
     /* Schedule a finger lift event
      */
@@ -96,6 +97,8 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     IOFixed last_y = 0;
     IOFixed last_click_x = 0;
     IOFixed last_click_y = 0;
+    IOFixed touch_start_x = 0;
+    IOFixed touch_start_y = 0;
     UInt32 barrel_switch_offset = 0;
     UInt32 eraser_switch_offset = 0;
     SInt32 last_id = 0;
@@ -105,10 +108,9 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     
     UInt32 click_tick = 0;
     bool right_click = false;
+    bool moved_during_right_click = false;
     bool start_scroll = true;
-    UInt16 compare_input_x = 0;
-    UInt16 compare_input_y = 0;
-    int compare_input_counter = 0;
+    UInt64 touch_start_time = 0;
     UInt64 last_click_time = 0;
     
     /* The transducer is checked for singletouch finger based operation and the pointer event dispatched. This function

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -73,10 +73,6 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      */
     IOReturn parseElements(UInt32) override;
 
-    /* Check if the first set of coordinate is within fat finger distance of the second set
-     */
-    bool isCloseTo(IOFixed x, IOFixed y, IOFixed other_x, IOFixed other_y);
-
     /* Schedule a finger lift event
      */
     void scheduleLift();


### PR DESCRIPTION
Now you can tap/hold/release and the menu persists or tap/hold/drag/release to select an item.

A timer is now used instead of ticks to determine if a right click should be triggered, and the delay for triggering has been shortened substantially (now it more closely matches Windows).

A deadzone is introduced after right clicking that ensures the menu does not close due to the cursor moving after the right click has been triggered.

After a right click has been triggered, inputs are considered hovers, not clicks, and a special case has been introduced to simulate a click when lifting the finger for a tap/hold/drag/release interaction. This makes using the menu natural for both tap/hold/release/tap to select item in menu or tap/hold/drag/release to select item in menu interaction patterns.

https://user-images.githubusercontent.com/201344/228681320-2ca0ee7d-5b6e-4c94-b3af-6aeb0a90cb11.mov


