### PR TITLE
Prevent phantom clicks when scrolling, clicks when right clicking

### DIFF
--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -25,67 +25,52 @@ OSDefineMetaClassAndStructors(VoodooI2CTouchscreenHIDEventDriver, VoodooI2CMulti
 // Override of VoodooI2CMultitouchHIDEventDriver
 
 bool VoodooI2CTouchscreenHIDEventDriver::checkFingerTouch(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event) {
-    bool got_transducer = false;
+    absolutetime_to_nanoseconds(timestamp, &last_interaction);
     
-    // If there is a finger touch event, decide if it is single or multitouch.
-    
-    for (int index = 0; index < digitiser.contact_count->getValue() + 1; index++) {
-        VoodooI2CDigitiserTransducer* transducer = OSDynamicCast(VoodooI2CDigitiserTransducer, event.transducers->getObject(index));
-        
-        if (!transducer)
-            return false;
-        
-        if (transducer->type == kDigitiserTransducerFinger && digitiser.contact_count->getValue() >= 2) {
-            // Our finger event is multitouch reset clicktick and wait to be dispatched to the multitouch engines.
-            
-            click_tick = 0;
-        }
-        
-        if (transducer->type == kDigitiserTransducerFinger && transducer->tip_switch.value()) {
-            got_transducer = true;
-            // Convert logical coordinates to IOFixed and Scaled;
-            
-            IOFixed x = ((transducer->coordinates.x.value() * 1.0f) / transducer->logical_max_x) * 65535;
-            IOFixed y = ((transducer->coordinates.y.value() * 1.0f) / transducer->logical_max_y) * 65535;
-            
-            checkRotation(&x, &y);
-            
-            // Get time in a usable format
-            uint64_t nanoseconds;
-            absolutetime_to_nanoseconds(timestamp, &nanoseconds);
+    // Avoid phantom clicks happening after scrolling
+    if ((last_interaction - last_multitouch_interaction) < MULTITOUCH_TIMEOUT) {
+        return false;
+    }
 
-            //  We need the first couple of single touch events to be in hover mode.  In modes such as Mission Control, this allows us
-            //  to select and drag windows vs just select and exit.  We are mimicking a cursor being moved into position prior to
-            //  executing a drag movement.  There is little noticeable effect in other circumstances.  This also assists in transitioning
-            //  between single / multitouch.
+    VoodooI2CDigitiserTransducer* transducer = OSDynamicCast(VoodooI2CDigitiserTransducer, event.transducers->getObject(0));
+    
+    if (transducer && transducer->type == kDigitiserTransducerFinger && transducer->tip_switch.value()) {
+        IOFixed x;
+        IOFixed y;
+        getCoordinates(transducer, &x, &y);
+        
+        if (
+            isCloseTo(x, y, last_click_x, last_click_y) &&
+            (last_interaction - last_click_time) <= DOUBLE_CLICK_TIME
+        ) {
+            // Double click start
+            // If we're clicking again where we just clicked, precisely position the pointer where it was before
+            x = last_click_x;
+            y = last_click_y;
+        }
+
+        if (!finger_down) {
+            finger_down = true;
+            touch_start_time = last_interaction;
+            touch_start_x = x;
+            touch_start_y = y;
+        } else if (!is_dragging) {
+            bool interaction_is_close_to_start = isCloseTo(x, y, touch_start_x, touch_start_y);
             
-            if (click_tick < HOVER_TICKS) {
-                buttons = HOVER;
-                touch_start_time = nanoseconds;
-                touch_start_x = x;
-                touch_start_y = y;
-            } else if (
+            if (
                 !right_click &&
-                digitiser.contact_count->getValue() == 1 &&
-                isCloseTo(x, y, touch_start_x, touch_start_y) &&
-                (nanoseconds - touch_start_time) >= RIGHT_CLICK_TIME
+                 interaction_is_close_to_start &&
+                (last_interaction - touch_start_time) >= RIGHT_CLICK_TIME
             ) {
-                right_click = true;
+                // Right click start
                 dispatchDigitizerEventWithTiltOrientation(timestamp, transducer->secondary_id, transducer->type, 0x1, RIGHT_CLICK, x, y);
                 dispatchDigitizerEventWithTiltOrientation(timestamp, transducer->secondary_id, transducer->type, 0x1, HOVER, x, y);
+                right_click = true;
             }
-            else {
-                buttons = transducer->tip_switch.value();
-            }
-
-            click_tick++;
-
 
             if (right_click) {
-                // After a right click has been executed, all interactions are now hovers
-                buttons = HOVER;
-
-                if (isCloseTo(x, y, touch_start_x, touch_start_y)) {
+                // Continue right click
+                if (interaction_is_close_to_start) {
                     // Adopt the location of the touch start so we don't stray and close the right click menu
                     x = touch_start_x;
                     y = touch_start_y;
@@ -94,32 +79,41 @@ bool VoodooI2CTouchscreenHIDEventDriver::checkFingerTouch(AbsoluteTime timestamp
                     // Track if we moved after the right click so we know if we need to click again on release
                     moved_during_right_click = true;
                 }
-            } else if (
-                isCloseTo(x, y, last_click_x, last_click_y) &&
-                (nanoseconds - last_click_time) <= DOUBLE_CLICK_TIME
-            ) {
-                // If we're clicking again where we just clicked, precisely position the pointer where it was before
-                x = last_click_x;
-                y = last_click_y;
+            } else {
+                // Check for drag start
+                if (!is_dragging && !is_drag_start_requested && !interaction_is_close_to_start) {
+                    scheduleDragStart();
+                    is_drag_start_requested = true;
+                }
             }
-            
-            // Only dispatch a single click event after we've done our hover ticks
-            if ((click_tick <= HOVER_TICKS + 1) || (x != last_x || y != last_y)) {
-                dispatchDigitizerEventWithTiltOrientation(timestamp, transducer->secondary_id, transducer->type, 0x1, buttons, x, y);
-            }
-
-            // Track last ID and coordinates so that we can send the finger lift event after our watch dog timeout.
-            last_x = x;
-            last_y = y;
-            last_id = transducer->secondary_id;
-
-            //  This timer serves to let us know when a finger based event is finished executing as well as let us
-            // know to reset the clicktick counter.
-            
-            scheduleLift();
         }
+
+        finger_interaction = HOVER;
+        if (is_dragging) {
+            finger_interaction = LEFT_CLICK;
+        }
+
+        dispatchDigitizerEventWithTiltOrientation(timestamp, transducer->secondary_id, transducer->type, 0x1, finger_interaction, x, y);
+
+        // Track last ID and coordinates so that we can send the finger lift event after our watch dog timeout.
+        last_x = x;
+        last_y = y;
+        last_id = transducer->secondary_id;
+
+        scheduleClick();
+        
+        return true;
     }
-    return got_transducer;
+
+    return false;
+}
+
+void VoodooI2CTouchscreenHIDEventDriver::getCoordinates(VoodooI2CDigitiserTransducer* transducer, IOFixed* x, IOFixed* y) {
+    // Convert logical coordinates to IOFixed and Scaled;
+    *x = ((transducer->coordinates.x.value() * 1.0f) / transducer->logical_max_x) * 65535;
+    *y = ((transducer->coordinates.y.value() * 1.0f) / transducer->logical_max_y) * 65535;
+
+    checkRotation(x, y);
 }
 
 void VoodooI2CTouchscreenHIDEventDriver::checkRotation(IOFixed* x, IOFixed* y) {
@@ -190,20 +184,20 @@ void VoodooI2CTouchscreenHIDEventDriver::fingerLift() {
     uint64_t now_abs;
     clock_get_uptime(&now_abs);
 
-    // This seems strange, but we go to hover mode after right clicking, and we need to execute a click if we've moved
-    if (right_click && moved_during_right_click) {
+    if (!is_dragging && (!right_click || moved_during_right_click)) {
         dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, LEFT_CLICK, last_x, last_y);
     }
-    
     dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, HOVER, last_x, last_y);
     
-    click_tick = 0;
     start_scroll = true;
+    finger_down = false;
     right_click = false;
+    is_dragging = false;
+    is_drag_start_requested = false;
     moved_during_right_click = false;
-    last_click_time = now_abs;
     last_click_x = last_x;
     last_click_y = last_y;
+    absolutetime_to_nanoseconds(now_abs, &last_click_time);
 }
 
 IOFramebuffer* VoodooI2CTouchscreenHIDEventDriver::getFramebuffer() {
@@ -249,10 +243,14 @@ void VoodooI2CTouchscreenHIDEventDriver::forwardReport(VoodooI2CMultitouchEvent 
         // Send multitouch information to the multitouch interface
 
         if (event.contact_count >= 2) {
+            // Immediately cancel any outstanding click
+            timer_source->cancelTimeout();
+            drag_timer_source->cancelTimeout();
+
+            absolutetime_to_nanoseconds(timestamp, &last_multitouch_interaction);
+
             if (event.contact_count == 2 && start_scroll) {
                 scrollPosition(timestamp, event);
-            } else if (event.contact_count == 2 && !start_scroll) {
-                scheduleLift();
             }
 
             multitouch_interface->handleInterruptReport(event, timestamp);
@@ -282,6 +280,13 @@ bool VoodooI2CTouchscreenHIDEventDriver::handleStart(IOService* provider) {
     timer_source = IOTimerEventSource::timerEventSource(this, OSMemberFunctionCast(IOTimerEventSource::Action, this, &VoodooI2CTouchscreenHIDEventDriver::fingerLift));
     
     if (!timer_source || work_loop->addEventSource(timer_source) != kIOReturnSuccess) {
+        IOLog("%s::Could not add timer source to work loop\n", getName());
+        return false;
+    }
+    
+    drag_timer_source = IOTimerEventSource::timerEventSource(this, OSMemberFunctionCast(IOTimerEventSource::Action, this, &VoodooI2CTouchscreenHIDEventDriver::dragStart));
+
+    if (!drag_timer_source || work_loop->addEventSource(drag_timer_source) != kIOReturnSuccess) {
         IOLog("%s::Could not add timer source to work loop\n", getName());
         return false;
     }
@@ -341,9 +346,21 @@ void VoodooI2CTouchscreenHIDEventDriver::scrollPosition(AbsoluteTime timestamp, 
         start_scroll = false;
     }
     
-    scheduleLift();
+//    scheduleClick();
 }
 
-void VoodooI2CTouchscreenHIDEventDriver::scheduleLift() {
+void VoodooI2CTouchscreenHIDEventDriver::dragStart() {
+    // Start dragging where the interaction began
+    uint64_t now_abs;
+    clock_get_uptime(&now_abs);
+    dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, LEFT_CLICK, touch_start_x, touch_start_y);
+    is_dragging = true;
+}
+
+void VoodooI2CTouchscreenHIDEventDriver::scheduleClick() {
     timer_source->setTimeoutMS(FINGER_LIFT_DELAY);
+}
+
+void VoodooI2CTouchscreenHIDEventDriver::scheduleDragStart() {
+    drag_timer_source->setTimeoutMS(DRAG_START_DELAY);
 }

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -189,15 +189,18 @@ void VoodooI2CTouchscreenHIDEventDriver::fingerLift() {
     }
     dispatchDigitizerEventWithTiltOrientation(now_abs, last_id, kDigitiserTransducerFinger, 0x1, HOVER, last_x, last_y);
     
+    last_click_x = last_x;
+    last_click_y = last_y;
+    absolutetime_to_nanoseconds(now_abs, &last_click_time);
+}
+
+void VoodooI2CTouchscreenHIDEventDriver::resetTouch() {
     start_scroll = true;
     finger_down = false;
     right_click = false;
     is_dragging = false;
     is_drag_start_requested = false;
     moved_during_right_click = false;
-    last_click_x = last_x;
-    last_click_y = last_y;
-    absolutetime_to_nanoseconds(now_abs, &last_click_time);
 }
 
 IOFramebuffer* VoodooI2CTouchscreenHIDEventDriver::getFramebuffer() {
@@ -246,6 +249,7 @@ void VoodooI2CTouchscreenHIDEventDriver::forwardReport(VoodooI2CMultitouchEvent 
             // Immediately cancel any outstanding click
             timer_source->cancelTimeout();
             drag_timer_source->cancelTimeout();
+            resetTouch();
 
             absolutetime_to_nanoseconds(timestamp, &last_multitouch_interaction);
 

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -113,14 +113,14 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     /* handler variables
      */
     
-    bool finger_down = false;
-    bool right_click = false;
-    bool is_dragging = false;
-    bool is_drag_start_requested = false;
+    bool is_finger_down = false;
+    bool is_right_clicking = false;
     bool moved_during_right_click = false;
-    bool start_scroll = true;
-    UInt64 last_multitouch_interaction = 0;
-    UInt64 last_interaction = 0;
+    bool is_dragging = false;
+    bool drag_start_requested = false;
+    bool is_scrolling = false;
+    UInt64 last_multitouch_interaction_time = 0;
+    UInt64 last_interaction_time = 0;
     UInt64 touch_start_time = 0;
     UInt64 last_click_time = 0;
     

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -24,11 +24,12 @@
 
 #include "VoodooI2CMultitouchHIDEventDriver.hpp"
 
-#define FAT_FINGER_ZONE     1000000 // 1000^2
+#define FAT_FINGER_ZONE     2250000 // 1500^2
 #define DOUBLE_CLICK_TIME   450 * 1000000
 #define RIGHT_CLICK_TIME    500 * 1000000
-#define FINGER_LIFT_DELAY   50
-#define HOVER_TICKS         3
+#define MULTITOUCH_TIMEOUT  250 * 1000000
+#define FINGER_LIFT_DELAY   50 // milliseconds
+#define DRAG_START_DELAY    50
 
 #define HOVER       0x0
 #define LEFT_CLICK  0x1
@@ -75,11 +76,16 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
 
     /* Schedule a finger lift event
      */
-    void scheduleLift();
+    void scheduleClick();
+
+    /* Schedule a drag start event
+     */
+    void scheduleDragStart();
 
  private:
     IOWorkLoop *work_loop;
     IOTimerEventSource *timer_source;
+    IOTimerEventSource *drag_timer_source;
     
     IOFramebuffer* active_framebuffer;
     UInt8 current_rotation;
@@ -87,7 +93,7 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     /* transducer variables
      */
     
-    UInt32 buttons = 0;
+    UInt32 finger_interaction = 0;
     UInt32 stylus_buttons = 0;
     IOFixed last_x = 0;
     IOFixed last_y = 0;
@@ -102,23 +108,48 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     /* handler variables
      */
     
-    UInt32 click_tick = 0;
+    bool finger_down = false;
     bool right_click = false;
+    bool is_dragging = false;
+    bool is_drag_start_requested = false;
     bool moved_during_right_click = false;
     bool start_scroll = true;
+    UInt64 last_multitouch_interaction = 0;
+    UInt64 last_interaction = 0;
     UInt64 touch_start_time = 0;
     UInt64 last_click_time = 0;
     
-    /* The transducer is checked for singletouch finger based operation and the pointer event dispatched. This function
-     * also handles a long-press, right-click function.
+    /* Checks if a finger touch is single or multi and branches accordingly
      *
      * @timestamp The timestamp of the current event being processed
-     *
      * @event The current event
      * @return `true` if we got a finger touch event, `false` otherwise
      */
     bool checkFingerTouch(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event);
     
+    /* Handle single touch interactions, as well as double-click and right-click
+     *
+     * @timestamp The timestamp of the current event being processed
+     * @event The current event
+     * @return `true` if we got a finger touch event, `false` otherwise
+     */
+    bool handleSingleTouch(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event);
+
+    /* Handle multi-touch interactions
+     *
+     * @timestamp The timestamp of the current event being processed
+     * @event The current event
+     * @return `true` if we got a finger touch event, `false` otherwise
+     */
+    bool handleMultiTouch(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event);
+
+    /* Convert logical coordinates to IOFixed and Scaled;
+     * @transducer A pointer to transducer to get coordinates from
+     * @x A pointer to an unset x coordinate
+     * @y A pointer to an unset y coordinate
+     */
+    void getCoordinates(VoodooI2CDigitiserTransducer* transducer, IOFixed* x, IOFixed* y);
+
     /* Checks to see if the x and y coordinates need to be modified
      * to account for a rotation
      *
@@ -126,7 +157,6 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      * @y A pointer to the y coordinate
      *
      */
-
     void checkRotation(IOFixed* x, IOFixed* y);
     
     /* This timeout based function executes a singletouch finger based pointer lift event as well as ensures that the pointer is not
@@ -134,6 +164,9 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      */
     void fingerLift();
     
+    /* Start dragging */
+    void dragStart();
+
     IOFramebuffer* getFramebuffer();
     
     /* Resets the pointer to the current finger location when scrolling begins

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -82,10 +82,15 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      */
     void scheduleDragStart();
 
+    /* Schedule a scroll end event
+     */
+    void scheduleScrollEnd();
+
  private:
     IOWorkLoop *work_loop;
     IOTimerEventSource *timer_source;
     IOTimerEventSource *drag_timer_source;
+    IOTimerEventSource *scroll_timer_source;
     
     IOFramebuffer* active_framebuffer;
     UInt8 current_rotation;
@@ -169,6 +174,9 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
     
     /* Start dragging */
     void dragStart();
+
+    /* End scrolling dragging */
+    void resetScroll();
 
     IOFramebuffer* getFramebuffer();
     

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -131,24 +131,9 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      * @return `true` if we got a finger touch event, `false` otherwise
      */
     bool checkFingerTouch(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event);
-    
-    /* Handle single touch interactions, as well as double-click and right-click
-     *
-     * @timestamp The timestamp of the current event being processed
-     * @event The current event
-     * @return `true` if we got a finger touch event, `false` otherwise
-     */
-    bool handleSingleTouch(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event);
-
-    /* Handle multi-touch interactions
-     *
-     * @timestamp The timestamp of the current event being processed
-     * @event The current event
-     * @return `true` if we got a finger touch event, `false` otherwise
-     */
-    bool handleMultiTouch(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event);
 
     /* Convert logical coordinates to IOFixed and Scaled;
+     *
      * @transducer A pointer to transducer to get coordinates from
      * @x A pointer to an unset x coordinate
      * @y A pointer to an unset y coordinate
@@ -160,13 +145,10 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      *
      * @x A pointer to the x coordinate
      * @y A pointer to the y coordinate
-     *
      */
     void checkRotation(IOFixed* x, IOFixed* y);
     
-    /* This timeout based function executes a singletouch finger based pointer lift event as well as ensures that the pointer is not
-     * stuck in a 'right click' mode after the long-press right-click function has been triggered.
-     */
+    /* Execute a singletouch finger based pointer click and lift event */
     void fingerLift();
 
     /* Reset variables associated with single touch */
@@ -186,7 +168,6 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      *
      * @event The current event
      */
-    
     void scrollPosition(AbsoluteTime timestamp, VoodooI2CMultitouchEvent event);
 };
 #endif /* VoodooI2CTouchscreenHIDEventDriver_hpp */

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.hpp
@@ -163,6 +163,9 @@ class EXPORT VoodooI2CTouchscreenHIDEventDriver : public VoodooI2CMultitouchHIDE
      * stuck in a 'right click' mode after the long-press right-click function has been triggered.
      */
     void fingerLift();
+
+    /* Reset variables associated with single touch */
+    void resetTouch();
     
     /* Start dragging */
     void dragStart();


### PR DESCRIPTION
This PR corrects some issues introduced by #67 and #69 where phantom clicks were happening when scrolling and before right clicking.

The fix is twofold:
1. Move anything that does a left click into a timed function, cancel the clicks if a multitouch interaction starts, don't perform the clicks if a right click has happened (except for the special case of right click + drag)
2. Ignore interactions that happen immediately after a multitouch interaction ends

Because of how this works, `click_tick` is no longer necessary and we're guaranteed to get several hovers before a click or drag happens.

Because drags are delayed, we have to be careful about where we start them, so we use the start location of the touch interaction, which seems to work well.

## Todo
* [x] Figure out what's causing jittering during drags
* [x] Figure out what's cause mouse to stay down after dragging sometimes, resulting in selection
* [x] Figure out why second tap in different location can sometimes turn into drag (scroll, tap, tap)
* [ ] Check stylus behavior due to changes that remove `for` loop from single touch interactions

## Questions about past code that was modified

* [ ] Find out if we need to send `transducer->tip_switch.value()` for finger touches or if `LEFT_CLICK` is fine
* [x] Find out why there was a `for` loop for transducers if there was always one
* [x] Find out why the old `for` loop went to `count + 1`
* [x] Find out if it's ever possible that the fetched transducer is null (could remove checks if not)
* [ ] Double check that returning `false` for `MULTITOUCH_TIMEOUT` is a problem