### PR TITLE
Fix Button bits for buttons attached to Finger Usage

### DIFF
--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -269,7 +269,16 @@ void VoodooI2CMultitouchHIDEventDriver::handleDigitizerTransducerReport(VoodooI2
                 }
                 break;
             case kHIDPage_Button:
-                setButtonState(&transducer->physical_button, (usage - 1), value, timestamp);
+                if (usage == kHIDUsage_Button_1) {
+                    // kHIDUsage_Button_1 is for the clickpad surface
+                    setButtonState(&transducer->physical_button, 0, value, timestamp);
+                } else {
+                    // kHIDUsage_Button_2/3 are for external buttons, thus should be reported
+                    // through the trackpoint device.
+                    transducer->has_secondary_button = true;
+                    setButtonState(&transducer->physical_button, (usage - 2), value, timestamp);
+                }
+                
                 handled    |= element_is_current;
                 break;
             case kHIDPage_Digitizer:


### PR DESCRIPTION
Fixes https://github.com/VoodooI2C/VoodooI2C/issues/527.

According to the precision trackpad [guidelines](https://learn.microsoft.com/en-us/windows-hardware/design/component-guidelines/touchpad-windows-precision-touchpad-collection#windows-precision-touchpad-input-reports), buttons 2 and 3 are for external buttons while button 1 is for the touchpad surface button itself. This PR fixes external buttons which are attached to the Finger usage instead of the top level report by checking for these two IDs.

Currently the I2C multitouch engine only supports either 2 external buttons or a single button underneath the touchpad surface. Should this be changed in this PR to allow all three buttons to be reported?