### PR TITLE
Use setValueData for USB Trackpads

### DIFF
--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -89,11 +89,6 @@
 					<integer>13</integer>
 				</dict>
 			</array>
-			<key>IOPropertyMatch</key>
-			<dict>
-				<key>Transport</key>
-				<string>I2C</string>
-			</dict>
 			<key>IOProbeScore</key>
 			<integer>300</integer>
 			<key>IOClass</key>

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
@@ -12,29 +12,12 @@
 OSDefineMetaClassAndStructors(VoodooI2CPrecisionTouchpadHIDEventDriver, VoodooI2CMultitouchHIDEventDriver);
 
 void VoodooI2CPrecisionTouchpadHIDEventDriver::enterPrecisionTouchpadMode() {
-    // This needs to be investigated further for USB touchpad support,
-    // it is currently commented out as it causes issues with input devices
-    // failing to wake from sleep and does not work on 10.15 and lower
-
-    /* if (version_major > CATALINA_MAJOR_VERSION) {
-        // Update value from hardware so we can rewrite mode when waking from sleep
-        digitiser.input_mode->getValue(kIOHIDValueOptionsUpdateElementValues);
-        digitiser.input_mode->setValue(INPUT_MODE_TOUCHPAD);
-        ready = true;
-        return;
-    }*/
+    UInt8 inputMode[] = { INPUT_MODE_TOUCHPAD };
     
-    // TODO: setValue appears to not work on Catalina or older
-    VoodooI2CPrecisionTouchpadFeatureReport buffer;
-    buffer.reportID = digitiser.input_mode->getReportID();
-    buffer.value = INPUT_MODE_TOUCHPAD;
-    buffer.reserved = 0x00;
-    IOBufferMemoryDescriptor* report = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, sizeof(VoodooI2CPrecisionTouchpadFeatureReport));
-    report->writeBytes(0, &buffer, sizeof(VoodooI2CPrecisionTouchpadFeatureReport));
-
-    hid_interface->setReport(report, kIOHIDReportTypeFeature, digitiser.input_mode->getReportID());
-    report->release();
-    
+    // Use setDataValue as it does not check for duplicate writes
+    OSData *value = OSData::withBytes(inputMode, sizeof(inputMode));
+    digitiser.input_mode->setDataValue(value);
+    OSSafeReleaseNULL(value);
     ready = true;
 }
 


### PR DESCRIPTION
`setValueData` has no checks for duplicate data, so I'm hoping will work after sleep and in older versions of macOS.
I've had someone test this to work in Catalina on a USB trackpad, but this probably requires more testing before being merged in. I'd rather let this sit to make sure it doesn't have issues before merging it in.

Tested Machines:
- Acer laptop with USB type cover (macOS 10.15)
  - Only issue is that VoodooI2CHID got unloaded if the type cover was disconnected for a few minutes :(
- Zenbook Duo UX481FA (I2C, macOS 12)