### PR TITLE
Passthrough Confidence Bit to macOS

### DIFF
--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -115,7 +115,6 @@ void VoodooI2CMultitouchHIDEventDriver::handleInterruptReport(AbsoluteTime times
         digitiser.current_report = 1;
     }
 
-    IOLog("I2C - Got Interrupt Report\n");
     handleDigitizerReport(timestamp, report_id);
 
     if (digitiser.current_report == digitiser.report_count) {
@@ -123,7 +122,6 @@ void VoodooI2CMultitouchHIDEventDriver::handleInterruptReport(AbsoluteTime times
         event.contact_count = digitiser.current_contact_count;
         event.transducers = digitiser.transducers;
 
-        IOLog("I2C - Trying to Forward Report\n");
         forwardReport(event, timestamp);
         
         digitiser.report_count = 1;
@@ -701,7 +699,6 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::parseElements(UInt32 usage) {
             }
         
             VoodooI2CDigitiserTransducer* transducer = OSDynamicCast(VoodooI2CDigitiserTransducer, wrapper->transducers->getObject(0));
-//            transducer->is_valid = true;
         
             for (int j = 0; j < transducer->collection->getChildElements()->getCount(); j++) {
                 IOHIDElement* element = OSDynamicCast(IOHIDElement, transducer->collection->getChildElements()->getObject(j));

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -246,6 +246,8 @@ void VoodooI2CTouchscreenHIDEventDriver::forwardReport(VoodooI2CMultitouchEvent 
         multitouch_interface->setProperty(kIOFBTransformKey, current_rotation, 8);
     }
     
+    IOLog("I2C - Touchscreen Forward Report\n");
+    
     if (event.contact_count) {
         // Send multitouch information to the multitouch interface
 
@@ -312,6 +314,16 @@ bool VoodooI2CTouchscreenHIDEventDriver::handleStart(IOService* provider) {
     active_framebuffer = getFramebuffer();
     if (active_framebuffer) {
         active_framebuffer->retain();
+    }
+    
+    if (digitiser.input_mode != nullptr) {
+        UInt8 inputMode[] = { 2 };
+        setProperty("Set Touchpadmode", kOSBooleanTrue);
+    
+        // Use setDataValue as it does not check for duplicate writes
+        OSData *value = OSData::withBytes(inputMode, sizeof(inputMode));
+        digitiser.input_mode->setDataValue(value);
+        OSSafeReleaseNULL(value);
     }
     
     return true;

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -246,8 +246,6 @@ void VoodooI2CTouchscreenHIDEventDriver::forwardReport(VoodooI2CMultitouchEvent 
         multitouch_interface->setProperty(kIOFBTransformKey, current_rotation, 8);
     }
     
-    IOLog("I2C - Touchscreen Forward Report\n");
-    
     if (event.contact_count) {
         // Send multitouch information to the multitouch interface
 
@@ -315,17 +313,7 @@ bool VoodooI2CTouchscreenHIDEventDriver::handleStart(IOService* provider) {
     if (active_framebuffer) {
         active_framebuffer->retain();
     }
-    
-    if (digitiser.input_mode != nullptr) {
-        UInt8 inputMode[] = { 2 };
-        setProperty("Set Touchpadmode", kOSBooleanTrue);
-    
-        // Use setDataValue as it does not check for duplicate writes
-        OSData *value = OSData::withBytes(inputMode, sizeof(inputMode));
-        digitiser.input_mode->setDataValue(value);
-        OSSafeReleaseNULL(value);
-    }
-    
+
     return true;
 }
 


### PR DESCRIPTION
Requires https://github.com/VoodooI2C/VoodooI2C/pull/547

This confidence bit should exist on most precision devices, so this should bring pretty easy palm rejection support to a lot of devices.